### PR TITLE
Fix jnp.diff causing issues during tracing

### DIFF
--- a/tests/units/models/test_construct.py
+++ b/tests/units/models/test_construct.py
@@ -65,4 +65,4 @@ def test_ferminet_can_be_constructed():
 
     key, subkey = jax.random.split(key)
     params = log_psi.init(subkey, init_pos)
-    log_psi.apply(params, init_pos)
+    jax.jit(log_psi.apply)(params, init_pos)

--- a/vmcnet/models/construct.py
+++ b/vmcnet/models/construct.py
@@ -48,7 +48,8 @@ def _get_nelec_per_spin(
     if isinstance(spin_split, int):
         return (nelec_total // spin_split,) * spin_split
     else:
-        return tuple(jnp.diff(jnp.array(spin_split), prepend=0, append=nelec_total))
+        spin_diffs = tuple(jnp.diff(jnp.array(spin_split)))
+        return (spin_split[0],) + spin_diffs + (nelec_total - spin_split[-1],)
 
 
 class SingleDeterminantFermiNet(flax.linen.Module):


### PR DESCRIPTION
The call to `jnp.diff` in `models.construct._get_nelec_per_spin` was causing issues during tracing with `jax.jit` or `jax.pmap`. Removing the `prepend` and `append` arguments seems to be a successful workaround, so these arguments are removed in this PR and their effects are reproduced explicitly.

Additionally, the test to construct a FermiNet is modified here to be jitted during model application to catch errors that occur due to tracing.