### PR TITLE
Remove donation of XLA buffers

### DIFF
--- a/vmcnet/mcmc/metropolis.py
+++ b/vmcnet/mcmc/metropolis.py
@@ -132,10 +132,7 @@ def make_jitted_burning_step(
     Returns:
         Callable: function with signature
             (data, params, key) -> (data, key),
-        with jax.pmap optionally applied if apply_pmap is True. Because it is totally
-        pure, the original (data, key) buffers are deleted in the pmapped version via
-        the `donate_argnums` argument so that XLA is potentially more memory-efficient
-        on the GPU. See :func:`jax.pmap`.
+        with jax.pmap optionally applied if apply_pmap is True.
     """
 
     def burning_step(data, params, key):
@@ -145,7 +142,7 @@ def make_jitted_burning_step(
     if not apply_pmap:
         return jax.jit(burning_step)
 
-    return utils.distribute.pmap(burning_step, donate_argnums=(0, 2))
+    return utils.distribute.pmap(burning_step)
 
 
 def make_jitted_walker_fn(
@@ -173,9 +170,7 @@ def make_jitted_walker_fn(
         Callable: funciton with signature
             (params, data, key) -> (mean accept prob, new data, new key)
         with jax.pmap optionally applied if pmapped is True, and jax.jit applied if
-        apply_pmap is False. Because it is totally pure, the original (data, key)
-        buffers are deleted in the pmapped version via the `donate_argnums` argument so
-        that XLA is potentially more memory-efficient on the GPU. See :func:`jax.pmap`.
+        apply_pmap is False.
     """
 
     def walker_fn(params, data, key):
@@ -186,7 +181,7 @@ def make_jitted_walker_fn(
     if not apply_pmap:
         return jax.jit(walker_fn)
 
-    pmapped_walker_fn = utils.distribute.pmap(walker_fn, donate_argnums=(1, 2))
+    pmapped_walker_fn = utils.distribute.pmap(walker_fn)
 
     def pmapped_walker_fn_with_single_accept_ratio(params, data, key):
         accept_ratio, data, key = pmapped_walker_fn(params, data, key)

--- a/vmcnet/updates/params.py
+++ b/vmcnet/updates/params.py
@@ -45,9 +45,7 @@ def create_grad_energy_update_param_fn(
             (data, params, optimizer_state, key)
             -> (new_params, new_optimizer_state, metrics, key)
         The function is pmapped if apply_pmap is True, and jitted if apply_pmap is
-        False. Because it is totally pure, the original (params, optimizer_state, key)
-        buffers are deleted in the pmapped version via the `donate_argnums` argument so
-        that XLA is potentially more memory-efficient on the GPU. See :func:`jax.pmap`.
+        False.
     """
     energy_data_val_and_grad = physics.core.create_value_and_grad_energy_fn(
         log_psi_apply, local_energy_fn, nchains


### PR DESCRIPTION
Tests were failing on GPU because we forgot to remove the `donate_argnums` argument to our pmap calls when we switched to saving old params. This PR fixes that bug.