### PR TITLE
Update lint.sh to not check files in notes, etc

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo "Running mypy to check for type errors"
-mypy .
+mypy vmcnet tests setup.py
 echo "Running flake8 to check for code style errors"
-flake8 --max-line-length=88 --select=C,E,F,W,B,B950 --ignore=E203,W503 --per-file-ignores="__init__.py:F401"
+flake8 --filename='./vmcnet/*.py','./tests/*.py','./setup.py' --max-line-length=88 --select=C,E,F,W,B,B950 --ignore=E203,W503 --per-file-ignores="__init__.py:F401"
 echo "Running pydocstyle to check for docstring style errors"
-pydocstyle --match='(.)*\.py' --add-ignore=D401
+pydocstyle ./vmcnet ./tests ./setup.py --match='(.)*\.py' --add-ignore=D401


### PR DESCRIPTION
I had some .py files in my notes folder to keep them out of git, but kept having the lint file complain about them. Seems like the best way to fix this case is to specifically point the linting to the code files and that way anything else like logs, notes, etc won't be linted. 