### PR TITLE
add pytest.mark.slow, with --runslow flag

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,35 @@
 """Initial pytest configuration.
 
-Added flags allow for tests to run in an N-device regime, via the flag
---chex_n_cpu_devices=N.
+On cpu, tests can run in an N-device regime, via the flag --chex_n_cpu_devices=N.
+
+Following the example in https://docs.pytest.org/en/latest/example/simple.html,
+tests marked with pytest.mark.slow will be skipped unless the --runslow option is
+provided.
 """
 import chex
+import pytest
 
 
 def pytest_addoption(parser):
     """Provide the --chex_n_cpu_devices arg to pytest."""
     parser.addoption("--chex_n_cpu_devices", type=int, default=4)
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
 
 
 def pytest_configure(config):
     """If --chex_n_cpu_devices=N is passed to pytest, run tests on N CPU threads."""
     chex.set_n_cpu_devices(config.getoption("chex_n_cpu_devices"))
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    """Modify pytest collection to respect the --runslow flag."""
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/tests/integrations/examples/test_harmonic_oscillator.py
+++ b/tests/integrations/examples/test_harmonic_oscillator.py
@@ -5,13 +5,16 @@ import os
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
+
 import vmcnet.examples.harmonic_oscillator as qho
-from tests.test_utils import assert_pytree_allclose
 from vmcnet.mcmc.simple_position_amplitude import (
     make_simple_position_amplitude_data,
 )
 from vmcnet.utils.distribute import distribute_vmc_state_from_checkpoint
 from vmcnet.utils.io import reload_vmc_state
+
+from tests.test_utils import assert_pytree_allclose
 
 from .sgd_train import sgd_vmc_loop_with_logging
 
@@ -30,6 +33,7 @@ def _make_initial_params_and_data(model_omega, nchains):
     return log_psi_model, params, random_particle_positions, amplitudes, key
 
 
+@pytest.mark.slow
 def test_five_particle_ground_state_harmonic_oscillator():
     """Test five non-interacting harmonic oscillators with two spins."""
     omega = 2.0
@@ -51,6 +55,7 @@ def test_five_particle_ground_state_harmonic_oscillator():
     )
 
 
+@pytest.mark.slow
 def test_harmonic_oscillator_vmc(caplog):
     """Test that the trainable sqrt(omega) converges to the true sqrt(spring constant).
 
@@ -105,6 +110,7 @@ def test_harmonic_oscillator_vmc(caplog):
     )
 
 
+@pytest.mark.slow
 def test_reload_reproduces_results(caplog, tmp_path):
     """Test that we can reproduce behavior by reloading vmc state from a checkpoint."""
     # Checkpoint directory info

--- a/tests/integrations/examples/test_hydrogen_like_atom.py
+++ b/tests/integrations/examples/test_hydrogen_like_atom.py
@@ -1,6 +1,8 @@
 """Test a hydrogen-like atom."""
 import jax
 import numpy as np
+import pytest
+
 import vmcnet.examples.hydrogen_like_atom as hla
 from vmcnet.mcmc.simple_position_amplitude import make_simple_position_amplitude_data
 
@@ -56,6 +58,7 @@ def _setup_hla_hyperparams_and_model():
     )
 
 
+@pytest.mark.slow
 def test_hydrogen_like_sgd_vmc(caplog):
     """Test the wavefn exp(-a * r) converges (in 3-D) to a = nuclear charge with SGD."""
     (
@@ -92,6 +95,7 @@ def test_hydrogen_like_sgd_vmc(caplog):
     np.testing.assert_allclose(jax.tree_leaves(params)[0], nuclear_charge, rtol=1e-5)
 
 
+@pytest.mark.slow
 def test_hydrogen_like_kfac_vmc(caplog):
     """Test exp(-a * r) converges (in 3-D) to a = nuclear charge with KFAC."""
     (

--- a/tests/integrations/mcmc/test_statistics.py
+++ b/tests/integrations/mcmc/test_statistics.py
@@ -4,6 +4,8 @@ import jax
 import jax.numpy as jnp
 import jax.random as random
 import numpy as np
+import pytest
+
 import vmcnet.mcmc.statistics as statistics
 
 
@@ -11,6 +13,7 @@ def _get_sample_size():
     return (1000000, 5)
 
 
+@pytest.mark.slow
 def test_independent_samples():
     """Test statistics on a chain with independent samples."""
     (nsamples, nchains) = _get_sample_size()
@@ -47,6 +50,7 @@ def _construct_correlated_samples(nsamples, nchains, decay_factor):
     return correlated_samples
 
 
+@pytest.mark.slow
 def test_correlated_samples():
     """Test statistics on sample chains with exponentially decaying autocorrelation."""
     (nsamples, nchains) = _get_sample_size()

--- a/tests/integrations/test_log_domain_kfac.py
+++ b/tests/integrations/test_log_domain_kfac.py
@@ -2,6 +2,7 @@
 import kfac_ferminet_alpha
 import jax
 import jax.numpy as jnp
+import pytest
 from kfac_ferminet_alpha import utils as kfac_utils
 
 import vmcnet.models as models
@@ -80,6 +81,7 @@ def _train(nsteps, loss_and_grad, model_params, batch, key, logdomain=False):
     return training_results
 
 
+@pytest.mark.slow
 def test_log_domain_dense_kfac_matches_dense_kfac():
     """Test that KFAC trains LogDomainDense in the same way as Dense.
 

--- a/tests/integrations/test_newton.py
+++ b/tests/integrations/test_newton.py
@@ -2,12 +2,14 @@
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 import vmcnet.mcmc as mcmc
 import vmcnet.train as train
 import vmcnet.utils as utils
 
 
+@pytest.mark.slow
 def test_vmc_loop_newtons_x_squared():
     """Test Newton's method to find the min of f(x) = (x - a)^2 + (x - a)^4.
 

--- a/tests/integrations/train/test_runners.py
+++ b/tests/integrations/train/test_runners.py
@@ -2,6 +2,7 @@
 import os
 
 import numpy as np
+import pytest
 
 import vmcnet.train as train
 
@@ -15,6 +16,7 @@ def _check_length_and_finiteness_of_metrics(nepochs, inner_logdir, metric_files)
         assert np.all(np.isfinite(metric))
 
 
+@pytest.mark.slow
 def test_run_molecule(mocker, tmp_path):
     """End-to-end test of the molecular runner (with smaller nchains/nepochs).
 

--- a/tests/units/examples/test_harmonic_oscillator.py
+++ b/tests/units/examples/test_harmonic_oscillator.py
@@ -2,12 +2,14 @@
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 import vmcnet.examples.harmonic_oscillator as qho
 
 from tests.test_utils import make_dummy_log_f
 
 
+@pytest.mark.slow
 def test_harmonic_osc_orbital_shape():
     """Test that putting in a pytree of inputs gives a pytree of orbitals."""
     orbital_model = qho.HarmonicOscillatorOrbitals(4.0)

--- a/tests/units/mcmc/test_statistics.py
+++ b/tests/units/mcmc/test_statistics.py
@@ -2,9 +2,12 @@
 
 import jax.numpy as jnp
 import numpy as np
+import pytest
+
 import vmcnet.mcmc.statistics as statistics
 
 
+@pytest.mark.slow
 def test_alternating_autocorr_per_chain():
     """Test per chain autocorrelation on alternating chains of +-n."""
     ntiles = 100
@@ -25,6 +28,7 @@ def test_alternating_autocorr_per_chain():
     np.testing.assert_allclose(autocorr, expected_autocorr, 1e-5)
 
 
+@pytest.mark.slow
 def test_alternating_multi_chain_autocorr():
     """Test multi chain autocorrelation on alternating chains of +-n."""
     nsamples = 20

--- a/tests/units/models/test_antiequivariance.py
+++ b/tests/units/models/test_antiequivariance.py
@@ -2,12 +2,15 @@
 import chex
 import jax.numpy as jnp
 import numpy as np
+import pytest
+
 import vmcnet.models as models
 import vmcnet.models.antiequivariance as antieq
 
 from .utils import get_elec_hyperparams, get_input_streams_from_hyperparams
 
 
+@pytest.mark.slow
 def test_slog_cofactor_output_with_batches():
     """Test slog_cofactor_antieq outputs correct value on simple inputs."""
     input = jnp.array([[1, 4, 7], [2, 5, 8], [3, 6, 9]])
@@ -29,6 +32,7 @@ def test_slog_cofactor_output_with_batches():
     np.testing.assert_allclose(y[1], full_expected_logs, rtol=1e-6)
 
 
+@pytest.mark.slow
 def test_slog_cofactor_antiequivarance():
     """Test slog_cofactor_antieq is antiequivariant."""
     input = jnp.array([[1, 4, 7], [2, 5, 8], [3, 6, 9]])
@@ -45,6 +49,7 @@ def test_slog_cofactor_antiequivarance():
     np.testing.assert_allclose(perm_logs, expected_perm_logs)
 
 
+@pytest.mark.slow
 def test_orbital_cofactor_layer_antiequivariance():
     """Test evaluation and antiequivariance of orbital cofactor equivariance layer."""
     # Generate example hyperparams and input streams

--- a/tests/units/models/test_antisymmetry.py
+++ b/tests/units/models/test_antisymmetry.py
@@ -2,6 +2,7 @@
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 import vmcnet.models as models
 
@@ -83,6 +84,7 @@ def _diagonal_product(flattened_square_matrix, n):
     return jnp.prod(diags, axis=-1, keepdims=True)
 
 
+@pytest.mark.slow
 def test_split_brute_force_antisymmetrize_vandermonde_product():
     """Test split brute-force antisym can be a product of vandermonde dets."""
     xs = [jnp.array([[3], [-2], [4]]), jnp.array([[1], [2], [3], [4]])]
@@ -107,6 +109,7 @@ def test_split_brute_force_antisymmetrize_vandermonde_product():
             np.testing.assert_allclose(output, det_product)
 
 
+@pytest.mark.slow
 def test_composed_brute_force_antisymmetrize_product():
     """Check composed brute-force antisym can make a product of determinants."""
     x_matrices = [

--- a/tests/units/models/test_core.py
+++ b/tests/units/models/test_core.py
@@ -1,9 +1,12 @@
 """Test core model building parts."""
 import jax
 import jax.numpy as jnp
+import pytest
+
 import vmcnet.models as models
 from vmcnet.utils.slog_helpers import array_to_slog
 from vmcnet.utils.typing import SLArray
+
 from tests.test_utils import (
     get_dense_and_log_domain_dense_same_params,
     get_resnet_and_log_domain_resnet_same_params,
@@ -11,6 +14,7 @@ from tests.test_utils import (
 )
 
 
+@pytest.mark.slow
 def test_dense_in_regular_and_log_domain_match():
     """Test that LogDomainDense does the same thing as Dense in the log domain."""
     nfeatures = 4
@@ -32,6 +36,7 @@ def test_dense_in_regular_and_log_domain_match():
     assert_pytree_allclose(slog_out, array_to_slog(out), rtol=1e-6)
 
 
+@pytest.mark.slow
 def test_resnet_in_regular_and_log_domain_match():
     """Test that LogDomainResnet does the same thing as SimpleResnet."""
     ninner = 4

--- a/tests/units/models/test_equivariance.py
+++ b/tests/units/models/test_equivariance.py
@@ -3,6 +3,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 import vmcnet.models as models
 import vmcnet.physics as physics
@@ -31,6 +32,7 @@ def test_electron_electron_add_norm():
     )
 
 
+@pytest.mark.slow
 def test_ferminet_one_electron_layer_shape_and_equivariance():
     """Test the equivariance of the one-electron layer in the FermiNet."""
     nchains, nelec_total, nion, d, permutation, spin_split, _ = get_elec_hyperparams()
@@ -76,6 +78,7 @@ def test_ferminet_one_electron_layer_shape_and_equivariance():
         np.testing.assert_allclose(output[:, permutation, :], perm_output, atol=1e-5)
 
 
+@pytest.mark.slow
 def test_ferminet_two_electron_layer_shape_and_equivariance():
     """Test that the two-electron stream is doubly equivariant."""
     nchains, nelec_total, nion, d, permutation, _, _ = get_elec_hyperparams()
@@ -111,6 +114,7 @@ def test_ferminet_two_electron_layer_shape_and_equivariance():
     )
 
 
+@pytest.mark.slow
 def test_split_dense_shape():
     """Test the output shape of the SplitDense layer."""
     nchains = 8

--- a/tests/units/models/test_sign_covariance.py
+++ b/tests/units/models/test_sign_covariance.py
@@ -3,6 +3,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 import vmcnet.models.sign_covariance as sign_cov
 from vmcnet.utils.slog_helpers import (
@@ -96,6 +97,7 @@ def test_get_sign_orbit_slog_array_list():
     np.testing.assert_allclose(sym_signs, expected_sym_signs)
 
 
+@pytest.mark.slow
 def test_make_slog_fn_sign_covariant():
     """Test making a fn of several spins sign covariant with respect to each spin."""
     nbatch = 5

--- a/tests/units/train/test_vmc.py
+++ b/tests/units/train/test_vmc.py
@@ -4,6 +4,7 @@ import logging
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 import vmcnet.mcmc as mcmc
 import vmcnet.train as train
@@ -18,6 +19,7 @@ def _make_different_pmappable_data(data):
     return jnp.concatenate([data + i for i in range(ndevices)])
 
 
+@pytest.mark.slow
 def test_vmc_loop_logging(caplog):
     """Test vmc_loop logging. Uses pytest's caplog fixture to capture logs."""
     nburn = 4
@@ -76,6 +78,7 @@ def test_vmc_loop_logging(caplog):
         assert len(caplog.records) == 1 + nepochs
 
 
+@pytest.mark.slow
 def test_vmc_loop_number_of_updates():
     """Test number of updates.
 


### PR DESCRIPTION
This PR adds a pytest marker to denote (currently) slow tests (arbitrarily, the ones which took > 1 second on my personal computer), and skip them with the default invocation of `pytest`. A `--runslow` flag is added so that the slow tests can be run with `pytest --runslow`. The marker serves two purposes:

1) to lower the activation energy for running the fast/unit tests frequently
2) to act as partial TODOs to address the unit tests (and maybe some of the integration tests too) which could be made significantly faster without sacrificing test rigor

Our long term goal should be to eliminate the marker from as many tests as possible without sacrificing test quality.