### PR TITLE
fix number of local devices in test_run_molecule

### DIFF
--- a/tests/integrations/train/test_runners.py
+++ b/tests/integrations/train/test_runners.py
@@ -1,6 +1,7 @@
 """Test of train.runners with near-default configs."""
 import os
 
+import jax
 import numpy as np
 import pytest
 
@@ -30,12 +31,12 @@ def test_run_molecule(mocker, tmp_path):
     to the runner with default configs, and that there is some potentially reasonable
     logging occurring. It will not generally catch more subtle bugs.
     """
-    vmc_nchains = 10
+    vmc_nchains = 10 * jax.local_device_count()
     vmc_nepochs = 5
     vmc_checkpoint_every = 2
     vmc_best_checkpoint_every = 4
 
-    eval_nchains = 20
+    eval_nchains = 20 * jax.local_device_count()
     eval_nepochs = 3
 
     mocker.patch("os.curdir", tmp_path)


### PR DESCRIPTION
The number of chains in `test_run_molecule` was not divisible by the number of local devices in some cases (the default CPU case), so this PR multiplies `vmc_nchains` and `eval_nchains` by `jax.local_device_count()`.

Next steps: this test takes a really long time (compared to our current test suite), so besides any refactoring/downsizing we might do to get the overall time down, we may want to add in test "levels" or an additional `--runveryslow` pytest cli option.