### PR TITLE
convert jvp rule to vjp, expose nan safety to cli

### DIFF
--- a/tests/integrations/examples/sgd_train.py
+++ b/tests/integrations/examples/sgd_train.py
@@ -4,6 +4,7 @@ import logging
 import jax
 
 import vmcnet.mcmc as mcmc
+import vmcnet.physics as physics
 import vmcnet.train as train
 import vmcnet.updates as updates
 import vmcnet.utils as utils
@@ -50,10 +51,11 @@ def sgd_vmc_loop_with_logging(
             learning_rate,
         )
 
+    energy_data_val_and_grad = physics.core.create_value_and_grad_energy_fn(
+        log_psi_model.apply, local_energy_fn, nchains
+    )
     update_param_fn = updates.params.create_grad_energy_update_param_fn(
-        log_psi_model.apply,
-        local_energy_fn,
-        nchains,
+        energy_data_val_and_grad,
         sgd_apply,
         get_position_from_data,
     )

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -129,6 +129,7 @@ def get_default_vmc_config() -> ConfigDict:
             "checkpoint_dir": "checkpoints",
             "checkpoint_variance_scale": 10,
             "nhistory_max": 200,
+            "nan_safe": True,
         }
     )
     return vmc_config


### PR DESCRIPTION
Using `defvjp`, we can avoid autodiff issues with transposing a `jvp` rule which has a linear `jnp.where` call to mask out nans. Thus in this PR we have supposed "nan-safety", in which if local energies or the corresponding gradients in the total energy gradient are `nan`, then they will be masked out before being added to the gradient. A flag is also added, `config.vmc.nan_safe`, which can be set to false to turn off nan-safety for debugging purposes. This is something that could be done if, for example, the gradient updates seem to be doing nothing at all, or the unclipped energies are `nan`.

In addition, this PR changes the signature of `updates/params/create_grad_energy_update_param_fn`, which now takes in `energy_data_val_and_grad` instead of a `local_energy_fn` and `log_psi_apply`. This fixes a bug with the molecular runner where using `Adam` meant that your local energies weren't getting clipped.