### PR TITLE
Remove support for nhidden_fermions_per_spin being an int [small]

### DIFF
--- a/tests/units/models/test_construct.py
+++ b/tests/units/models/test_construct.py
@@ -111,7 +111,7 @@ def _make_embedded_particle_ferminets():
     cyclic_spins = False
     backflow = _get_backflow(spin_split, ndense_list, cyclic_spins, ion_pos)
     invariance_backflow = _get_backflow(spin_split, ndense_list, cyclic_spins, ion_pos)
-    nhidden_fermions_per_spin_vals = [(2, 3), 2]
+    nhidden_fermions_per_spin_vals = [(2, 3), (4, 0)]
 
     for nhidden_fermions_per_spin in nhidden_fermions_per_spin_vals:
         log_psi = models.construct.EmbeddedParticleFermiNet(
@@ -247,7 +247,7 @@ def test_ferminet_can_be_constructed():
 def test_ferminet_can_be_evaluated():
     """Check evaluation of FermiNet does not fail."""
     key, init_pos, log_psis = _make_ferminets()
-    (_jit_eval_model(key, init_pos, log_psi) for log_psi in log_psis)
+    [_jit_eval_model(key, init_pos, log_psi) for log_psi in log_psis]
 
 
 def test_embedded_particle_ferminet_can_be_constructed():
@@ -259,7 +259,7 @@ def test_embedded_particle_ferminet_can_be_constructed():
 def test_embedded_particle_ferminet_can_be_evaluated():
     """Check evaluation of EmbeddedParticleFerminet does not fail."""
     key, init_pos, log_psis = _make_embedded_particle_ferminets()
-    (_jit_eval_model(key, init_pos, log_psi) for log_psi in log_psis)
+    [_jit_eval_model(key, init_pos, log_psi) for log_psi in log_psis]
 
 
 def test_orbital_cofactor_net_can_be_constructed():

--- a/vmcnet/models/construct.py
+++ b/vmcnet/models/construct.py
@@ -599,11 +599,8 @@ class EmbeddedParticleFermiNet(flax.linen.Module):
             particles, `spin_split` should be either the number 2 (for closed-shell
             systems) or should be a Sequence with length 1 whose element is less than
             the total number of electrons.
-        nhidden_fermions_per_spin (int or Sequence[int]): number of hidden fermions to
-            generate for each spin. If an integer, the same number will be used for
-            each spin. If a sequence, must have length nspins, and each value in the
-            sequence will specify the number of hidden fermions for the corresponding
-            spin.
+        nhidden_fermions_per_spin (Sequence[int]): number of hidden fermions to
+            generate for each spin. Must have length nspins.
         backflow (Callable): function which computes position features from the electron
             positions. Has the signature
             (elec pos of shape (..., n, d))
@@ -652,7 +649,7 @@ class EmbeddedParticleFermiNet(flax.linen.Module):
     """
 
     spin_split: SpinSplit
-    nhidden_fermions_per_spin: Union[int, Sequence[int]]
+    nhidden_fermions_per_spin: Sequence[int]
     backflow: Backflow
     ndeterminants: int
     kernel_initializer_orbital_linear: WeightInitializer
@@ -667,22 +664,6 @@ class EmbeddedParticleFermiNet(flax.linen.Module):
     invariance_use_bias: bool = True
     invariance_register_kfac: bool = True
     determinant_fn: Optional[Callable[[ArrayList], jnp.ndarray]] = None
-
-    def _get_total_nelec_per_spin(self, nelec_per_spin: Sequence[int]) -> Sequence[int]:
-        if isinstance(self.nhidden_fermions_per_spin, int):
-            return [n + self.nhidden_fermions_per_spin for n in nelec_per_spin]
-
-        return [
-            n + self.nhidden_fermions_per_spin[i] for i, n in enumerate(nelec_per_spin)
-        ]
-
-    def _get_invariance_output_shape_per_spin(
-        self, nspins: int, d: int
-    ) -> Sequence[Tuple[int, int]]:
-        if isinstance(self.nhidden_fermions_per_spin, int):
-            return [(self.nhidden_fermions_per_spin, d)] * nspins
-
-        return [(n, d) for n in self.nhidden_fermions_per_spin]
 
     def _get_invariant_tensor(
         self, output_shape_per_spin: Sequence[Tuple[int, int]]
@@ -740,10 +721,7 @@ class EmbeddedParticleFermiNet(flax.linen.Module):
             self.spin_split, visible_nelec_total
         )
         nspins = len(visible_nelec_per_spin)
-        if (
-            isinstance(self.nhidden_fermions_per_spin, Sequence)
-            and len(self.nhidden_fermions_per_spin) != nspins
-        ):
+        if len(self.nhidden_fermions_per_spin) != nspins:
             raise ValueError(
                 "Length of nhidden_fermions_per_spin does not match number of spins. "
                 "Provided {} for {} spins.".format(
@@ -751,12 +729,15 @@ class EmbeddedParticleFermiNet(flax.linen.Module):
                 )
             )
 
-        invariance_output_shape_per_spin = self._get_invariance_output_shape_per_spin(
-            nspins, d
-        )
+        invariance_output_shape_per_spin = [
+            (n, d) for n in self.nhidden_fermions_per_spin
+        ]
         invariance = self._get_invariant_tensor(invariance_output_shape_per_spin)
 
-        total_nelec_per_spin = self._get_total_nelec_per_spin(visible_nelec_per_spin)
+        total_nelec_per_spin = [
+            n + self.nhidden_fermions_per_spin[i]
+            for i, n in enumerate(visible_nelec_per_spin)
+        ]
         # Using numpy not jnp here to avoid Jax thinking this is a dynamic value and
         # complaining when it gets used within the constructed FermiNet.
         total_spin_split = tuple(np.cumsum(np.array(total_nelec_per_spin))[:-1])


### PR DESCRIPTION
I was going to remove support for spin_split being an int as well, but it's a pretty scary task. So many usages and docstrings to update, for unclear benefit since we have the complexity of that handled reasonably well at this point.

But I think since this is more contained and isn't being used directly as a splitting input anyway, might as well at least remove support for nhidden_fermions_per_spin being an int. 