### PR TITLE
Support unweighted products sign covariance

### DIFF
--- a/tests/units/models/test_sign_symmetry.py
+++ b/tests/units/models/test_sign_symmetry.py
@@ -180,9 +180,7 @@ def test_make_sl_array_list_fn_sign_covariant():
     np.testing.assert_allclose(same_sign_result, result, atol=1e-6)
 
 
-@pytest.mark.slow
-def test_products_sign_covariance():
-    """Test ProductsSignCovariance can be evaluated and is sign covariant."""
+def _test_products_sign_covariance(dout: int, use_weights: bool):
     nbatch = 5
     nelec_per_spin = (2, 5)
     d = 2
@@ -194,9 +192,8 @@ def test_products_sign_covariance():
     flip_sign_inputs = [inputs[0], -inputs[1]]
     same_sign_inputs = [-inputs[0], -inputs[1]]
 
-    dout = 3
     model = sign_sym.ProductsSignCovariance(
-        dout, weights.get_kernel_initializer("orthogonal")
+        dout, weights.get_kernel_initializer("orthogonal"), use_weights=use_weights
     )
     result, params = model.init_with_output(subkey, inputs)
 
@@ -206,3 +203,10 @@ def test_products_sign_covariance():
 
     assert_pytree_allclose(flip_sign_result, -result)
     assert_pytree_allclose(same_sign_result, result)
+
+
+@pytest.mark.slow
+def test_products_sign_covariance():
+    """Test ProductsSignCovariance can be evaluated and is sign covariant."""
+    _test_products_sign_covariance(3, True)
+    _test_products_sign_covariance(1, False)

--- a/vmcnet/models/construct.py
+++ b/vmcnet/models/construct.py
@@ -393,6 +393,7 @@ def get_sign_covariance_from_config(
             1,
             kernel_init_constructor(model_config.products_covariance.kernel_init),
             model_config.products_covariance.register_kfac,
+            use_weights=model_config.products_covariance.use_weights,
         )
 
     else:

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -155,6 +155,7 @@ def get_default_model_config() -> ConfigDict:
             "products_covariance": {
                 "kernel_init": {"type": "orthogonal", "scale": 2.0},
                 "register_kfac": True,
+                "use_weights": False,
             },
             "multiply_by_eq_features": False,
         }


### PR DESCRIPTION
Support AntiequivarianceNet with product-based sign covariance, using an unweighted sum of products to make sure the output is antisymmetric as it should be.

Not too hopeful that this is an interesting ansatz, as it seems a lot like generating sums of products of regular ferminet determinants. But 🤷  still seems worth a shot, and if either the cofactors or the per particle determinants does well with just this simple combination function, it would be pretty interesting.