### PR TITLE
Fix backflow for EmbeddedParticleFermiNet

### DIFF
--- a/tests/units/models/test_construct.py
+++ b/tests/units/models/test_construct.py
@@ -146,8 +146,8 @@ def _make_embedded_particle_ferminets():
     invariance_compute_input_streams = _get_compute_input_streams(ion_pos)
     invariance_backflow = _get_backflow(spin_split, ndense_list, cyclic_spins)
 
-    for extra_dims_per_spin in [(2, 3), (4, 0)]:
-        total_spin_split = (spin_split[0] + extra_dims_per_spin[0],)
+    for nhidden_fermions_per_spin in [(2, 3), (4, 0)]:
+        total_spin_split = (spin_split[0] + nhidden_fermions_per_spin[0],)
         backflow = _get_backflow(total_spin_split, ndense_list, cyclic_spins)
         log_psi = models.construct.EmbeddedParticleFermiNet(
             spin_split,
@@ -162,7 +162,7 @@ def _make_embedded_particle_ferminets():
             isotropic_decay=True,
             determinant_fn=None,
             determinant_fn_mode=DeterminantFnMode.PARALLEL_EVEN,
-            extra_dims_per_spin=extra_dims_per_spin,
+            nhidden_fermions_per_spin=nhidden_fermions_per_spin,
             invariance_compute_input_streams=invariance_compute_input_streams,
             invariance_backflow=invariance_backflow,
             invariance_kernel_initializer=models.weights.get_kernel_initializer(
@@ -190,7 +190,7 @@ def _make_extended_orbital_matrix_ferminets():
     backflow = _get_backflow(spin_split, ndense_list, cyclic_spins)
     extra_backflow = _get_backflow(spin_split, ndense_list, cyclic_spins)
 
-    for extra_dims_per_spin, use_separate_invariance_backflow in [
+    for nhidden_fermions_per_spin, use_separate_invariance_backflow in [
         ((2, 3), True),
         ((4, 0), False),
     ]:
@@ -220,7 +220,7 @@ def _make_extended_orbital_matrix_ferminets():
             isotropic_decay=True,
             determinant_fn=None,
             determinant_fn_mode=DeterminantFnMode.PARALLEL_EVEN,
-            extra_dims_per_spin=extra_dims_per_spin,
+            nhidden_fermions_per_spin=nhidden_fermions_per_spin,
             invariance_backflow=invariance_backflow,
             invariance_kernel_initializer=models.weights.get_kernel_initializer(
                 "he_normal"

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -168,7 +168,7 @@ def get_default_model_config() -> ConfigDict:
             "embedded_particle_ferminet": ConfigDict(
                 {
                     **base_ferminet_config,
-                    "extra_dims_per_spin": (2, 2),
+                    "nhidden_fermions_per_spin": (2, 2),
                     "invariance": ConfigDict(
                         {
                             "input_streams": embedded_particle_input_streams,
@@ -184,7 +184,7 @@ def get_default_model_config() -> ConfigDict:
             "extended_orbital_matrix_ferminet": ConfigDict(
                 {
                     **base_ferminet_config,
-                    "extra_dims_per_spin": (2, 2),
+                    "nhidden_fermions_per_spin": (2, 2),
                     "use_separate_invariance_backflow": False,
                     "invariance": ConfigDict(
                         {


### PR DESCRIPTION
**The bug**
There was a bug in my initial implementation of EmbeddedParticleFermiNet: the orbitals were generated using the total spin_split for visible and hidden electrons, but the backflow used was just the standard one, with the spin_split for the visible electrons only. 

Surprisingly, this doesn't totally mess everything up. For example, if we're running Nitrogen with visible electrons (5,2) and hidden electrons (4,4), the backflow ends up using spin_split of (5,), which essentially amounts to a split of (5, 10).  That is, it brackets the particles into two groups like so:
`[(5 visible up spin)] [(4 hidden up spin) (2 visible down spin) (4 hidden down spin)]`

Since the hidden particles are all permutation-invariant with respect to all of the spins, the output of this still ends up just being 5 equivariant streams, 4 invariant streams, 2 equivariant streams, and 4 invariant streams, and the antisymmetry still works as expected. This is all essentially an artifact of the fact that, since you generate the hidden particles invariantly, you don't actually need any invariance or equivariance in the backflow with respect to the hidden particles. 

Nonetheless, seems better to do this the expected way, using the total spin_split for the backflow as well as the orbital generation. 

**The fix**
The fix I've implemented is to make a backflow with the right spin_split especially for the EmbeddedParticleFermiNet case in `_get_model_from_config`. This feels slightly awkward as we're requiring the user of EmbeddedParticleFermiNet to be smart and realize they need to tweak their backflow. However, I'm not sure there's a way to fix this case more neatly without adding some complexity to all the other models (i.e., one option would be to make all backflow components take spin_split as an input at run-time, but this seems like more complexity than it's worth). So, hopefully the note I added to the docstring will be enough to remind us of this quirk. 