### PR TITLE
Use numpy instead of jax.numpy for stats calculations

### DIFF
--- a/vmcnet/mcmc/statistics.py
+++ b/vmcnet/mcmc/statistics.py
@@ -135,7 +135,8 @@ def get_stats_summary(samples: np.ndarray) -> Dict[str, np.float32]:
         dictionary: a summary of the statistics, with keys "average", "variance",
         "std_err", and "integrated_autocorrelation"
     """
-    average = np.mean(samples)
+    # Nested mean may be more numerically stable than single mean
+    average = np.mean(np.mean(samples, axis=-1), axis=-1)
     autocorr_curve, variance = multi_chain_autocorr_and_variance(samples)
     iac = tau(autocorr_curve)
     std_err = np.sqrt(iac * variance / np.size(samples))


### PR DESCRIPTION
This has the effects of 
1. Improving the numerical stability, as we were seeing errors of ~1% of the correlation energy from averaging the eval local energies on GPUs with jnp.mean()
2. Meaning we'll rely on CPU memory rather than GPU memory when we load all the local energies from the evaluation phase, which should prevent us from running out.
