### PR TITLE
Fix full determinant mode

### DIFF
--- a/vmcnet/models/construct.py
+++ b/vmcnet/models/construct.py
@@ -1069,9 +1069,9 @@ class ExtendedOrbitalMatrixFermiNet(FermiNet):
         self, elec_pos: jnp.ndarray, orbitals_split: ParticleSplit
     ) -> Tuple[int, ...]:
         visible_nelec_total = elec_pos.shape[-2]
-        all_nelec_total = visible_nelec_total + sum(self.nhidden_fermions_per_spin)
 
         if self.full_det:
+            all_nelec_total = visible_nelec_total + sum(self.nhidden_fermions_per_spin)
             nsplits = get_nsplits(orbitals_split)
             return (all_nelec_total,) * nsplits
 


### PR DESCRIPTION
Previously, we were using a single orbital split for full_det mode, which meant we were using a single dense kernel to generate the orbital matrix columns for both spin up and spin down particles. This PR corrects that mistake so that we always use separate kernels to generate separate orbitals per_spin. Full determinant mode is then implemented by generating extra orbitals for each spin and concatenating the orbital matrices together before taking determinants. 

This actually turns out to be an even simpler implementation than the previous one!