### PR TITLE
Fix default config logic so that settings can all be set independently

### DIFF
--- a/tests/units/train/test_parse_config_flags.py
+++ b/tests/units/train/test_parse_config_flags.py
@@ -69,6 +69,23 @@ def test_parse_config_with_valid_flags_including_tuple(mocker):
     _assert_configs_equal(config, expected_config)
 
 
+def test_setting_duplicated_config_flag_sets_only_desired_flag(mocker):
+    """Test changing normal_init.type only affects the desired instance of the flag.
+
+    This is a regression test as reuse of the same Dict object used to mean that setting
+    any instance of normal_init.type would change all other instances too.
+    """
+    flag_values = flags.FlagValues()
+    mocker.patch(
+        "sys.argv",
+        ["vmcnet", "--config.model.ferminet.bias_init_orbital_linear.type=CHANGED"],
+    )
+    _, config = parse_flags(flag_values)
+
+    assert config.model.bias_init_orbital_linear.type == "CHANGED"
+    assert config.model.backflow.bias_init_1e_stream.type == "normal"
+
+
 def test_parse_config_with_invalid_reload_param(mocker):
     """Verify that error is thrown when an invalid reload flag is passed."""
     flag_values = flags.FlagValues()

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -25,7 +25,7 @@ def _copy_all_dicts(config: Dict) -> Dict:
     }
 
     If this config is used directly, setting a command line flag like
-    --config.sub1.val=3 will override both config.sub1.a and config.sub2.a, which is
+    --config.sub1.val=3 will override both config.sub1.val and config.sub2.val, which is
     not the intended behavior. Calling config=copy_all_dicts(config) before turning this
     into a ConfigDict solves the problem by making separate copies of both subconfigs.
 


### PR DESCRIPTION
I discovered a bit of a nasty bug in our ConfigDict logic. It turns out that due to reuse of several objects in `default_config`, such as `normal_init` and `ferminet_backflow`, several different configuration settings were being tied together and any attempt to override one of them would override all.

For example, on current master running `vmc-molecule --config.logging_level=INFO --config.model.ferminet.backflow.kernel_init_mixed.scale=12345` also sets the scale of `kernel_init_2e_1e_stream` to 12345, since both use the same `orthogonal_init` object. 

In fixing this, I also figured I'd try to standardize the conventions in the default_config file a bit. Currently, I've gone with the convention that we only call `ConfigDict()` on the top-level dicts that are used directly as ConfigDicts, since these calls also convert subdicts to ConfigDicts by default. And to address the bug, I wrote a custom cloning method that explicitly makes separate clones of every subdict in the object.

LMK what you think!