### PR TITLE
Optimize orbital generation for FermiNet

### DIFF
--- a/vmcnet/models/construct.py
+++ b/vmcnet/models/construct.py
@@ -1,4 +1,5 @@
 """Combine pieces to form full models."""
+# TODO (ggoldsh): split this file into smaller component files
 from enum import Enum
 import functools
 from typing import Callable, List, Optional, Sequence, Tuple


### PR DESCRIPTION
By multiplying norbitals_per_spin by ndeterminants, and thus generating all the orbitals for all the determinants in a single SplitDense layer instead of with one SplitDense layer per determinant.

PS there are two tangential things that came to mind in working on this PR, which I'll add follow-up comments for so you can respond individually. 