### PR TITLE
Make ordering more logical when splitting orbitals into separate determinants

### DIFF
--- a/vmcnet/models/construct.py
+++ b/vmcnet/models/construct.py
@@ -656,20 +656,22 @@ def _reshape_raw_ferminet_orbitals(
         ArrayList: input orbitals reshaped to
         [norb_splits: (ndeterminants, ..., nelec[i], norbitals[i])]
     """
-    # Reshape to [norb_splits: (..., nhidden[i], norbitals[i], ndeterminants)]
+    # Reshape to [norb_splits: (..., nhidden[i], ndeterminants, norbitals[i])]
     orbitals = [
         jnp.reshape(
             orb,
             (
                 *orb.shape[:-1],
-                orb.shape[-1] // ndeterminants,
+                # This ordering ensures elements corresponding to a single determinant
+                # come from adjacent blocks of the raw orbitals.
                 ndeterminants,
+                orb.shape[-1] // ndeterminants,
             ),
         )
         for orb in orbitals
     ]
     # Move axis to [norb_splits: (ndeterminants, ..., nelec[i], norbitals[i])]
-    return [jnp.moveaxis(orb, -1, 0) for orb in orbitals]
+    return [jnp.moveaxis(orb, -2, 0) for orb in orbitals]
 
 
 class FermiNet(flax.linen.Module):


### PR DESCRIPTION
Previously the raw array of `ndets * norbitals` would be split into determinants in an interleaved way, where i.e. indices `0, ndets, 2*ndets`, etc would all end up in the same orbital.

This change makes it a little easier to work with the orbitals by changing it so the first determinant corresponds to indices `1,2, .., ndets-1`, and later blocks correspond to later determinants.