### PR TITLE
Adjust naming of fa and ga to better match paper

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,7 @@ def get_default_config_with_chosen_model(
     model_type,
     use_det_resnet=None,
     determinant_fn_mode=None,
-    brute_force_subtype=None,
+    explicit_antisym_subtype=None,
     use_products_covariance=None,
 ):
     """Get default ConfigDict for a particular model type."""
@@ -30,8 +30,8 @@ def get_default_config_with_chosen_model(
         config.model.embedded_particle_ferminet.determinant_fn_mode = (
             determinant_fn_mode
         )
-    if brute_force_subtype is not None:
-        config.model.brute_force_antisym.antisym_type = brute_force_subtype
+    if explicit_antisym_subtype is not None:
+        config.model.explicit_antisym.antisym_type = explicit_antisym_subtype
     if use_products_covariance is not None:
         config.model.orbital_cofactor_net.use_products_covariance = (
             use_products_covariance

--- a/tests/units/models/test_antisymmetry.py
+++ b/tests/units/models/test_antisymmetry.py
@@ -87,8 +87,8 @@ def _diagonal_product(flattened_square_matrix, n):
 
 
 @pytest.mark.slow
-def test_split_brute_force_antisymmetrize_vandermonde_product():
-    """Test split brute-force antisym can be a product of vandermonde dets."""
+def test_factorized_antisymmetrize_vandermonde_product():
+    """Test factorized antisym can be a product of vandermonde dets."""
     xs = [jnp.array([[3], [-2], [4]]), jnp.array([[1], [2], [3], [4]])]
     vandermonde_dets = [
         ((-2) - 3) * (4 - 3) * (4 - (-2)),
@@ -116,8 +116,8 @@ def test_split_brute_force_antisymmetrize_vandermonde_product():
 
 
 @pytest.mark.slow
-def test_composed_brute_force_antisymmetrize_product():
-    """Check composed brute-force antisym can make a product of determinants."""
+def test_generic_antisymmetrize_product():
+    """Check generic antisymmetrize can make a product of determinants."""
     x_matrices = [
         jnp.array(
             [

--- a/tests/units/models/test_construct.py
+++ b/tests/units/models/test_construct.py
@@ -508,13 +508,13 @@ def test_per_particle_dets_net_can_be_evaluated():
 
 
 def test_factorized_antisymmetry_can_be_constructed():
-    """Check construction of SplitBruteForceAntisymmetryWithDecay does not fail."""
+    """Check construction of FactorizedAntisymmetry does not fail."""
     _make_factorized_antisymmetries()
 
 
 @pytest.mark.slow
 def test_factorized_antisymmetry_can_be_evaluated():
-    """Check evaluation of SplitBruteForceAntisymmetryWithDecay does not fail."""
+    """Check evaluation of FactorizedAntisymmetry does not fail."""
     key, init_pos, slog_psis = _make_factorized_antisymmetries()
     [
         _jit_eval_model_and_verify_output_shape(key, init_pos, slog_psi)
@@ -523,13 +523,13 @@ def test_factorized_antisymmetry_can_be_evaluated():
 
 
 def test_generic_antisymmetry_can_be_constructed():
-    """Check construction of ComposedBruteForceAntisymmetryWithDecay does not fail."""
+    """Check construction of GenericAntisymmetry does not fail."""
     _make_generic_antisymmetry()
 
 
 @pytest.mark.slow
 def test_generic_antisymmetry_can_be_evaluated():
-    """Check evaluation of ComposedBruteForceAntisymmetryWithDecay does not fail."""
+    """Check evaluation of GenericAntisymmetry does not fail."""
     key, init_pos, slog_psi = _make_generic_antisymmetry()
     _jit_eval_model_and_verify_output_shape(key, init_pos, slog_psi)
 
@@ -544,23 +544,23 @@ def test_get_model_from_default_config():
         model_type,
         use_det_resnet=True,
         determinant_fn_mode=None,
-        brute_force_subtype=None,
+        explicit_antisym_subtype=None,
         use_products_covariance=False,
     ):
         model_config = get_default_config_with_chosen_model(
             model_type,
             use_det_resnet=use_det_resnet,
             determinant_fn_mode=determinant_fn_mode,
-            brute_force_subtype=brute_force_subtype,
+            explicit_antisym_subtype=explicit_antisym_subtype,
             use_products_covariance=use_products_covariance,
         ).model
         models.construct.get_model_from_config(
             model_config, nelec, ion_pos, ion_charges
         )
 
-    for model_type in ["brute_force_antisym"]:
+    for model_type in ["explicit_antisym"]:
         for subtype in ["factorized", "generic"]:
-            _construct_model(model_type, brute_force_subtype=subtype)
+            _construct_model(model_type, explicit_antisym_subtype=subtype)
     for model_type in [
         "ferminet",
         "embedded_particle_ferminet",

--- a/vmcnet/models/antisymmetry.py
+++ b/vmcnet/models/antisymmetry.py
@@ -187,7 +187,7 @@ class GenericAntisymmetrize(flax.linen.Module):
     layer.
 
     For each leaf of a pytree, a given function of all the leaves is antisymmetrized
-    over the second-to-last axis of each leaf. These brute-force antisymmetrization
+    over the second-to-last axis of each leaf. These explicit antisymmetrization
     operations are composed with each other (they commute, so the order does not
     matter), giving an output which is antisymmetric with respect to particle exchange
     within each leaf but not with respect to particle exchange between leaves.

--- a/vmcnet/models/construct.py
+++ b/vmcnet/models/construct.py
@@ -314,7 +314,7 @@ def get_model_from_config(
             multiply_by_eq_features=model_config.multiply_by_eq_features,
         )
 
-    elif model_config.type == "brute_force_antisym":
+    elif model_config.type == "explicit_antisym":
         jastrow_config = model_config.jastrow
 
         def _get_two_body_decay_jastrow():
@@ -398,7 +398,7 @@ def get_model_from_config(
             )
         else:
             raise ValueError(
-                "Unsupported brute-force antisymmetry type; {} was requested".format(
+                "Unsupported explicit antisymmetry type; {} was requested".format(
                     model_config.antisym_type
                 )
             )
@@ -1271,7 +1271,7 @@ class AntiequivarianceNet(flax.linen.Module):
 
 
 class FactorizedAntisymmetry(flax.linen.Module):
-    """A sum of products of brute-force antisymmetrized ResNets, composed with backflow.
+    """A sum of products of explicitly antisymmetrized ResNets, composed with backflow.
 
     This connects the computational graph between a backflow, a factorized
     antisymmetrized ResNet, and a jastrow.
@@ -1310,7 +1310,7 @@ class FactorizedAntisymmetry(flax.linen.Module):
                 r_ee of shape (batch_dims, n, n, d),
             )
                 -> log jastrow of shape (batch_dims,)
-        rank (int): The rank of the brute-force antisymmetry. In practical terms, the
+        rank (int): The rank of the explicit antisymmetry. In practical terms, the
             number of resnets to antisymmetrize for each spin. This is analogous to
             ndeterminants for regular FermiNet.
         ndense_resnet (int): number of dense nodes in each layer of each antisymmetrized

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -214,7 +214,7 @@ def get_default_model_config() -> Dict:
         # "antiequivariance" model type
         "orbital_cofactor_net": antieq_config,
         "per_particle_dets_net": antieq_config,
-        "brute_force_antisym": {
+        "explicit_antisym": {
             "input_streams": input_streams,
             "backflow": ferminet_backflow,
             "antisym_type": "generic",  # factorized or generic


### PR DESCRIPTION
Changes instances of SplitAntisymmetry/SplitBruteForceAntisymmetry/etc. to FactorizedAntisymmetry and Composed/Double to Generic to better align with the preprint (https://arxiv.org/abs/2112.03491). Also added links to the preprint in the FA and GA layers as well as the model constructors.