### PR TITLE
Define Array type in typing file and reference everywhere else

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,7 @@ import numpy as np
 import vmcnet.mcmc as mcmc
 import vmcnet.models as models
 import vmcnet.train.default_config as default_config
-from vmcnet.utils.typing import PyTree
+from vmcnet.utils.typing import Array, PyTree
 
 
 def get_default_config_with_chosen_model(
@@ -113,8 +113,8 @@ def _get_log_domain_params_for_dense_layer(params):
 
 
 def get_dense_and_log_domain_dense_same_params(
-    key: jnp.ndarray,
-    batch: jnp.ndarray,
+    key: Array,
+    batch: Array,
     dense_layer: models.core.Dense,
 ) -> Tuple[frozen_dict.FrozenDict, frozen_dict.FrozenDict]:
     """Get matching params for Dense and LogDomainDense layers."""
@@ -125,8 +125,8 @@ def get_dense_and_log_domain_dense_same_params(
 
 
 def get_resnet_and_log_domain_resnet_same_params(
-    key: jnp.ndarray,
-    batch: jnp.ndarray,
+    key: Array,
+    batch: Array,
     resnet: models.core.SimpleResNet,
 ) -> Tuple[frozen_dict.FrozenDict, frozen_dict.FrozenDict]:
     """Get matching params for SimpleResNet and LogDomainResnet models."""

--- a/tests/units/mcmc/test_position_amplitude_core.py
+++ b/tests/units/mcmc/test_position_amplitude_core.py
@@ -6,6 +6,7 @@ import jax.numpy as jnp
 import numpy as np
 
 import vmcnet.mcmc.position_amplitude_core as pacore
+from vmcnet.utils.typing import Array
 
 from tests.test_utils import make_dummy_data_params_and_key, dummy_model_apply
 
@@ -31,9 +32,9 @@ def test_gaussian_proposal_with_nonzero_step_width():
 def _get_data_for_test_update() -> Tuple[
     pacore.PositionAmplitudeData,
     pacore.PositionAmplitudeData,
-    jnp.ndarray,
-    jnp.ndarray,
-    jnp.ndarray,
+    Array,
+    Array,
+    Array,
 ]:
     pos = jnp.array([[0, 0], [0, 0], [0, 0], [0, 0]])
     proposed_pos = jnp.array([[1, 1], [2, 2], [3, 4], [4, 3]])

--- a/tests/units/models/test_antiequivariance.py
+++ b/tests/units/models/test_antiequivariance.py
@@ -10,7 +10,7 @@ import pytest
 import vmcnet.models as models
 import vmcnet.models.antiequivariance as antieq
 from vmcnet.utils.slog_helpers import slog_sum_over_axis
-from vmcnet.utils.typing import ParticleSplit
+from vmcnet.utils.typing import Array, ParticleSplit
 
 from .utils import get_elec_hyperparams, get_input_streams_from_hyperparams
 
@@ -114,7 +114,7 @@ def test_slog_cofactor_antiequivariance():
 
 def _assert_slogabs_signs_allclose_to_one(
     nchains: int,
-    output_i: Tuple[jnp.ndarray, jnp.ndarray],
+    output_i: Tuple[Array, Array],
     nelec_i: int,
 ):
     assert len(output_i) == 2
@@ -127,8 +127,8 @@ def _assert_slogabs_signs_allclose_to_one(
 
 def _assert_permuted_slog_values_allclose(
     split_perm_i: Tuple[int, ...],
-    output_i: Tuple[jnp.ndarray, jnp.ndarray],
-    perm_output_i: Tuple[jnp.ndarray, jnp.ndarray],
+    output_i: Tuple[Array, Array],
+    perm_output_i: Tuple[Array, Array],
     flips_i: int,
     rtol: float = 1e-7,
     atol: float = 1e-7,

--- a/tests/units/models/test_construct.py
+++ b/tests/units/models/test_construct.py
@@ -9,7 +9,7 @@ import pytest
 import vmcnet.models as models
 import vmcnet.models.sign_symmetry as sign_sym
 from vmcnet.models.construct import DeterminantFnMode
-from vmcnet.utils.typing import ArrayList
+from vmcnet.utils.typing import Array, ArrayList
 
 from tests.test_utils import get_default_config_with_chosen_model
 
@@ -247,7 +247,7 @@ def _make_antiequivariance_net_with_resnet_sign_covariance(
     compute_input_streams = _get_compute_input_streams(ion_pos)
     backflow = _get_backflow(spin_split, ndense_list, cyclic_spins=cyclic_spins)
 
-    def backflow_based_equivariance(x: ArrayList) -> jnp.ndarray:
+    def backflow_based_equivariance(x: ArrayList) -> Array:
         concat_x = jnp.concatenate(x, axis=-2)
         return _get_backflow(spin_split, ((9,), (2,), (1,)), cyclic_spins=True)(
             concat_x
@@ -257,7 +257,7 @@ def _make_antiequivariance_net_with_resnet_sign_covariance(
         backflow_based_equivariance, axis=-3
     )
 
-    def array_list_sign_covariance(x: ArrayList) -> jnp.ndarray:
+    def array_list_sign_covariance(x: ArrayList) -> Array:
         return jnp.sum(odd_equivariance(x), axis=-2)
 
     slog_psi = models.construct.AntiequivarianceNet(

--- a/tests/units/models/test_core.py
+++ b/tests/units/models/test_core.py
@@ -5,7 +5,7 @@ import pytest
 
 import vmcnet.models as models
 from vmcnet.utils.slog_helpers import array_to_slog
-from vmcnet.utils.typing import SLArray
+from vmcnet.utils.typing import Array, SLArray
 
 from tests.test_utils import (
     get_dense_and_log_domain_dense_same_params,
@@ -44,7 +44,7 @@ def test_resnet_in_regular_and_log_domain_match():
     nlayers = 5
 
     # Define activation function with simple analog in log domain
-    def activation_fn(x: jnp.ndarray) -> jnp.ndarray:
+    def activation_fn(x: Array) -> Array:
         return jnp.sign(x) * (x ** 2) / 10
 
     # Define log domain version of the same activation function

--- a/tests/units/models/test_sign_symmetry.py
+++ b/tests/units/models/test_sign_symmetry.py
@@ -13,7 +13,7 @@ from vmcnet.utils.slog_helpers import (
     array_to_slog,
     array_list_to_slog,
 )
-from vmcnet.utils.typing import ArrayList, SLArray, SLArrayList
+from vmcnet.utils.typing import Array, ArrayList, SLArray, SLArrayList
 
 from tests.test_utils import assert_pytree_allclose
 
@@ -69,8 +69,8 @@ def test_get_sign_orbit_slog_array_list():
 
 
 def _make_simple_nn_layers(
-    dinput: int, dout: int, key: jnp.ndarray
-) -> Callable[[jnp.ndarray], jnp.ndarray]:
+    dinput: int, dout: int, key: Array
+) -> Callable[[Array], Array]:
     dhidden = 4
     key, subkey = jax.random.split(key)
     # Biases important here to avoid starting with a perfectly odd function
@@ -79,7 +79,7 @@ def _make_simple_nn_layers(
     weights1 = jax.random.normal(key, (dinput, dhidden))
     weights2 = jax.random.normal(subkey, (dhidden, dout))
 
-    def apply_layers(x: jnp.ndarray) -> jnp.ndarray:
+    def apply_layers(x: Array) -> Array:
         output = jnp.matmul(x + biases, weights1)
         output = jnp.tanh(output)
         output = jnp.matmul(output, weights2)
@@ -105,7 +105,7 @@ def _test_sign_covariance_or_invariance(is_invariance: bool, atol: float):
     dout = 3
     nn_layers = _make_simple_nn_layers(nelec_total * d, dout, subkey)
 
-    def fn(x: ArrayList) -> jnp.ndarray:
+    def fn(x: ArrayList) -> Array:
         all_vals = jnp.concatenate(x, axis=-1)
         return nn_layers(all_vals)
 

--- a/tests/units/models/utils.py
+++ b/tests/units/models/utils.py
@@ -5,6 +5,7 @@ import jax
 import jax.numpy as jnp
 
 import vmcnet.models as models
+from vmcnet.utils.typing import Array
 
 
 def get_elec_hyperparams() -> Tuple[
@@ -30,7 +31,7 @@ def get_elec_hyperparams() -> Tuple[
 
 def get_elec_and_ion_pos_from_hyperparams(
     nchains: int, nelec_total: int, nion: int, d: int, permutation: Tuple[int, ...]
-) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, Optional[jnp.ndarray]]:
+) -> Tuple[Array, Array, Array, Optional[Array]]:
     """Get electron, permuted electron, and ion positions from hyperparameters."""
     key = jax.random.PRNGKey(0)
     key, subkey = jax.random.split(key)
@@ -38,7 +39,7 @@ def get_elec_and_ion_pos_from_hyperparams(
     permuted_elec_pos = elec_pos[:, permutation, :]
     key, subkey = jax.random.split(key)
     if nion > 0:
-        ion_pos: Optional[jnp.ndarray] = jax.random.normal(subkey, (nion, d))
+        ion_pos: Optional[Array] = jax.random.normal(subkey, (nion, d))
     else:
         ion_pos = None
     return key, elec_pos, permuted_elec_pos, ion_pos
@@ -47,13 +48,13 @@ def get_elec_and_ion_pos_from_hyperparams(
 def get_input_streams_from_hyperparams(
     nchains: int, nelec_total: int, nion: int, d: int, permutation: Tuple[int, ...]
 ) -> Tuple[
-    jnp.ndarray,
-    Optional[jnp.ndarray],
-    Optional[jnp.ndarray],
-    jnp.ndarray,
-    Optional[jnp.ndarray],
-    Optional[jnp.ndarray],
-    jnp.ndarray,
+    Array,
+    Optional[Array],
+    Optional[Array],
+    Array,
+    Optional[Array],
+    Optional[Array],
+    Array,
 ]:
     """Get electron and permuted electron input streams given hyperparameters."""
     key, elec_pos, permuted_elec_pos, ion_pos = get_elec_and_ion_pos_from_hyperparams(

--- a/tests/units/utils/test_slog_helpers.py
+++ b/tests/units/utils/test_slog_helpers.py
@@ -5,10 +5,10 @@ import jax.numpy as jnp
 
 import vmcnet.utils.slog_helpers as helpers
 from tests.test_utils import assert_pytree_allclose
-from vmcnet.utils.typing import SLArray
+from vmcnet.utils.typing import Array, SLArray
 
 
-def _get_array_and_slog_vals() -> Tuple[jnp.ndarray, SLArray]:
+def _get_array_and_slog_vals() -> Tuple[Array, SLArray]:
     vals = jnp.array([jnp.e, -jnp.e ** 0.5, 0, 1])
     signs = jnp.array([1, -1, 0, 1])
     logs = jnp.array([1, 0.5, -jnp.inf, 0])

--- a/vmcnet/examples/harmonic_oscillator.py
+++ b/vmcnet/examples/harmonic_oscillator.py
@@ -5,10 +5,10 @@ import jax.numpy as jnp
 
 import vmcnet.models as models
 import vmcnet.physics as physics
-from vmcnet.utils.typing import P, ModelApply
+from vmcnet.utils.typing import Array, P, ModelApply
 
 
-def make_hermite_polynomials(x: jnp.ndarray) -> jnp.ndarray:
+def make_hermite_polynomials(x: Array) -> Array:
     """Compute the first n Hermite polynomials evaluated at n points.
 
     Because the Hermite polynomials are orthogonal, they have a three-term recurrence
@@ -21,10 +21,10 @@ def make_hermite_polynomials(x: jnp.ndarray) -> jnp.ndarray:
     along the first axis and the polynomials along the second.
 
     Args:
-        x (jnp.ndarray): an array of shape (..., nparticles, 1)
+        x (Array): an array of shape (..., nparticles, 1)
 
     Returns:
-        jnp.ndarray: an array of shape (..., nparticles, nparticles), where the
+        Array: an array of shape (..., nparticles, nparticles), where the
         (..., i, j)th entry corresponds to H_j(x_i).
     """
     nparticles = x.shape[-2]
@@ -94,7 +94,7 @@ class HarmonicOscillatorOrbitals(flax.linen.Module):
     omega_init: jnp.float32
 
     @flax.linen.compact
-    def _single_leaf_call(self, x: jnp.ndarray) -> jnp.ndarray:
+    def _single_leaf_call(self, x: Array) -> Array:
         # x and omega * x have shape (..., n, 1)
         sqrt_omega_x = models.core.Dense(
             1,
@@ -144,7 +144,7 @@ def make_harmonic_oscillator_spin_half_model(
     return models.core.ComposedModel([split_spin_fn, orbitals, logdet_fn])
 
 
-def harmonic_oscillator_potential(omega: jnp.float32, x: jnp.ndarray) -> jnp.float32:
+def harmonic_oscillator_potential(omega: jnp.float32, x: Array) -> jnp.float32:
     """Potential energy for independent harmonic oscillators with spring constant omega.
 
     This function computes sum_i 0.5 * (omega * x_i)^2. If x has more than one axis,
@@ -156,7 +156,7 @@ def harmonic_oscillator_potential(omega: jnp.float32, x: jnp.ndarray) -> jnp.flo
 
     Args:
         omega (jnp.float32): spring constant
-        x (jnp.ndarray): array of particle positions, where the first axis corresponds
+        x (Array): array of particle positions, where the first axis corresponds
             to particle index
 
     Returns:
@@ -182,7 +182,7 @@ def make_harmonic_oscillator_local_energy(
     """
     kinetic_fn = physics.kinetic.create_continuous_kinetic_energy(log_psi_apply)
 
-    def potential_fn(params: P, x: jnp.ndarray):
+    def potential_fn(params: P, x: Array):
         del params
         return harmonic_oscillator_potential(omega, x)
 

--- a/vmcnet/examples/hydrogen_like_atom.py
+++ b/vmcnet/examples/hydrogen_like_atom.py
@@ -6,7 +6,7 @@ import jax.numpy as jnp
 
 import vmcnet.physics as physics
 import vmcnet.models as models
-from vmcnet.utils.typing import P, ModelApply
+from vmcnet.utils.typing import Array, P, ModelApply
 
 
 class HydrogenLikeWavefunction(flax.linen.Module):
@@ -27,15 +27,15 @@ class HydrogenLikeWavefunction(flax.linen.Module):
     init_decay_rate: jnp.float32
 
     @flax.linen.compact
-    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
+    def __call__(self, x: Array) -> Array:
         """Log of isotropic exponential decay. Computes -decay_rate * ||x||.
 
         Args:
-            x (jnp.ndarray): single electron positions, of shape (..., 1, d), where d
+            x (Array): single electron positions, of shape (..., 1, d), where d
                 is the dimension of the system
 
         Returns:
-            jnp.ndarray: log of exponential decay wavefunction, with shape x.shape[:-2]
+            Array: log of exponential decay wavefunction, with shape x.shape[:-2]
         """
         r = jnp.linalg.norm(x, axis=-1)
         scaled_r = models.core.Dense(
@@ -49,7 +49,7 @@ class HydrogenLikeWavefunction(flax.linen.Module):
 
 
 def make_hydrogen_like_local_energy(
-    log_psi_apply: Callable[[P, jnp.ndarray], Union[jnp.float32, jnp.ndarray]],
+    log_psi_apply: Callable[[P, Array], Union[jnp.float32, Array]],
     charge: jnp.float32,
     d: int = 3,
 ) -> ModelApply[P]:

--- a/vmcnet/mcmc/dynamic_width_position_amplitude.py
+++ b/vmcnet/mcmc/dynamic_width_position_amplitude.py
@@ -11,7 +11,7 @@ from .position_amplitude_core import (
     PositionAmplitudeWalkerData,
 )
 from vmcnet.utils.distribute import mean_all_local_devices
-from vmcnet.utils.typing import P, ModelApply
+from vmcnet.utils.typing import Array, P, ModelApply
 
 
 class MoveMetadata(TypedDict):
@@ -45,8 +45,8 @@ DWPAData = DynamicWidthPositionAmplitudeData
 
 
 def make_dynamic_width_position_amplitude_data(
-    position: jnp.ndarray,
-    amplitude: jnp.ndarray,
+    position: Array,
+    amplitude: Array,
     std_move: jnp.float32,
     move_acceptance_sum: jnp.float32 = 0.0,
     moves_since_update: jnp.int32 = 0,
@@ -54,8 +54,8 @@ def make_dynamic_width_position_amplitude_data(
     """Create instance of DynamicWidthPositionAmplitudeData.
 
     Args:
-        position (jnp.ndarray): the particle positions
-        amplitude (jnp.ndarray): the wavefunction amplitudes
+        position (Array): the particle positions
+        amplitude (Array): the wavefunction amplitudes
         std_move (jnp.float32): std for gaussian moves
         move_acceptance_sum (jnp.float32): sum of the acceptance ratios of each step
             since the last update. Default of 0 should not be altered if using this
@@ -122,7 +122,7 @@ def make_threshold_adjust_std_move(
 def make_update_move_metadata_fn(
     nmoves_per_update: jnp.int32,
     adjust_std_move_fn: Callable[[jnp.float32, jnp.float32], jnp.float32],
-) -> Callable[[MoveMetadata, jnp.ndarray], MoveMetadata]:
+) -> Callable[[MoveMetadata, Array], MoveMetadata]:
     """Create a function that updates the move_metadata periodically.
 
     Periodicity is controlled by the nmoves_per_update parameter and the logic for
@@ -142,7 +142,7 @@ def make_update_move_metadata_fn(
     """
 
     def update_move_metadata(
-        move_metadata: MoveMetadata, current_move_mask: jnp.ndarray
+        move_metadata: MoveMetadata, current_move_mask: Array
     ) -> MoveMetadata:
         std_move = move_metadata["std_move"]
         move_acceptance_sum = move_metadata["move_acceptance_sum"]

--- a/vmcnet/mcmc/metropolis.py
+++ b/vmcnet/mcmc/metropolis.py
@@ -6,17 +6,17 @@ import jax
 import jax.numpy as jnp
 
 import vmcnet.utils as utils
-from vmcnet.utils.typing import D, P
+from vmcnet.utils.typing import Array, D, P
 
-MetropolisStep = Callable[[P, D, jnp.ndarray], Tuple[jnp.float32, D, jnp.ndarray]]
+MetropolisStep = Callable[[P, D, Array], Tuple[jnp.float32, D, Array]]
 WalkerFn = MetropolisStep[P, D]
-BurningStep = Callable[[P, D, jnp.ndarray], Tuple[D, jnp.ndarray]]
+BurningStep = Callable[[P, D, Array], Tuple[D, Array]]
 
 
 def make_metropolis_step(
-    proposal_fn: Callable[[P, D, jnp.ndarray], Tuple[D, jnp.ndarray]],
-    acceptance_fn: Callable[[P, D, D], jnp.ndarray],
-    update_data_fn: Callable[[D, D, jnp.ndarray], D],
+    proposal_fn: Callable[[P, D, Array], Tuple[D, Array]],
+    acceptance_fn: Callable[[P, D, D], Array],
+    update_data_fn: Callable[[D, D, Array], D],
 ) -> MetropolisStep[P, D]:
     """Factory to create a function which takes a single metropolis step.
 
@@ -36,7 +36,7 @@ def make_metropolis_step(
             the signature (params, data, key) -> proposed_data, key
         acceptance_fn (Callable): acceptance function which produces a vector of numbers
             used to create a mask for accepting the proposals. Has the signature
-            (params, data, proposed_data) -> jnp.ndarray: acceptance probabilities
+            (params, data, proposed_data) -> Array: acceptance probabilities
         update_data_fn (Callable): function used to update the data given the original
             data, the proposed data, and the array mask identifying which proposals to
             accept. Has the signature
@@ -48,15 +48,13 @@ def make_metropolis_step(
         one)
     """
 
-    def metrop_step_fn(
-        params: P, data: D, key: jnp.ndarray
-    ) -> Tuple[jnp.float32, D, jnp.ndarray]:
+    def metrop_step_fn(params: P, data: D, key: Array) -> Tuple[jnp.float32, D, Array]:
         """Take a single metropolis step."""
         key, subkey = jax.random.split(key)
         proposed_data, key = proposal_fn(params, data, key)
         accept_prob = acceptance_fn(params, data, proposed_data)
         move_mask = cast(
-            jnp.ndarray,
+            Array,
             jax.random.uniform(subkey, shape=accept_prob.shape) < accept_prob,
         )
         new_data = update_data_fn(data, proposed_data, move_mask)
@@ -70,9 +68,9 @@ def walk_data(
     nsteps: int,
     params: P,
     data: D,
-    key: jnp.ndarray,
+    key: Array,
     metrop_step_fn: MetropolisStep[P, D],
-) -> Tuple[jnp.float32, D, jnp.ndarray]:
+) -> Tuple[jnp.float32, D, Array]:
     """Take multiple Metropolis-Hastings steps.
 
     This function is roughly equivalent to:
@@ -92,14 +90,14 @@ def walk_data(
         data (pytree-like): data to walk (update) with each step
         params (pytree-like): parameters passed to proposal_fn and acceptance_fn, e.g.
             model params
-        key (jnp.ndarray): an array with shape (2,) representing a jax PRNG key passed
+        key (Array): an array with shape (2,) representing a jax PRNG key passed
             to proposal_fn and used to randomly accept proposals with probabilities
             output by acceptance_fn
         metrop_step_fn (Callable): function which does a metropolis step. Has the
             signature (data, params, key) -> (mean accept prob, new data, new key)
 
     Returns:
-        (jnp.float32, pytree-like, jnp.ndarray): acceptance probability, new data,
+        (jnp.float32, pytree-like, Array): acceptance probability, new data,
             new jax PRNG key split (possibly multiple times) from previous one
     """
 
@@ -139,7 +137,7 @@ def make_jitted_burning_step(
         with jax.pmap optionally applied if apply_pmap is True.
     """
 
-    def burning_step(params: P, data: D, key: jnp.ndarray) -> Tuple[D, jnp.ndarray]:
+    def burning_step(params: P, data: D, key: Array) -> Tuple[D, Array]:
         _, data, key = metrop_step_fn(params, data, key)
         return data, key
 
@@ -177,9 +175,7 @@ def make_jitted_walker_fn(
         apply_pmap is False.
     """
 
-    def walker_fn(
-        params: P, data: D, key: jnp.ndarray
-    ) -> Tuple[jnp.float32, D, jnp.ndarray]:
+    def walker_fn(params: P, data: D, key: Array) -> Tuple[jnp.float32, D, Array]:
         accept_ratio, data, key = walk_data(nsteps, params, data, key, metrop_step_fn)
         accept_ratio = utils.distribute.pmean_if_pmap(accept_ratio)
         return accept_ratio, data, key
@@ -190,8 +186,8 @@ def make_jitted_walker_fn(
     pmapped_walker_fn = utils.distribute.pmap(walker_fn)
 
     def pmapped_walker_fn_with_single_accept_ratio(
-        params: P, data: D, key: jnp.ndarray
-    ) -> Tuple[jnp.float32, D, jnp.ndarray]:
+        params: P, data: D, key: Array
+    ) -> Tuple[jnp.float32, D, Array]:
         accept_ratio, data, key = pmapped_walker_fn(params, data, key)
         accept_ratio = utils.distribute.get_first(accept_ratio)
         return accept_ratio, data, key
@@ -204,8 +200,8 @@ def burn_data(
     nsteps_to_burn: int,
     params: P,
     data: D,
-    key: jnp.ndarray,
-) -> Tuple[D, jnp.ndarray]:
+    key: Array,
+) -> Tuple[D, Array]:
     """Repeatedly apply a burning step.
 
     Args:
@@ -214,12 +210,12 @@ def burn_data(
         nsteps_to_burn (int): number of times to call burning_step
         data (pytree-like): initial data
         params (pytree-like): parameters passed to the burning step
-        key (jnp.ndarray): an array with shape (2,) representing a jax PRNG key passed
+        key (Array): an array with shape (2,) representing a jax PRNG key passed
             to proposal_fn and used to randomly accept proposals with probabilities
             output by acceptance_fn
 
     Returns:
-        (pytree-like, jnp.ndarray): new data, new key
+        (pytree-like, Array): new data, new key
     """
     logging.info("Burning data for %d steps", nsteps_to_burn)
     for _ in range(nsteps_to_burn):
@@ -228,25 +224,25 @@ def burn_data(
 
 
 def gaussian_proposal(
-    positions: jnp.ndarray, std_move: jnp.float32, key: jnp.ndarray
-) -> Tuple[jnp.ndarray, jnp.ndarray]:
+    positions: Array, std_move: jnp.float32, key: Array
+) -> Tuple[Array, Array]:
     """Simple symmetric gaussian proposal in all positions at once.
 
     Args:
-        positions (jnp.ndarray): original positions
+        positions (Array): original positions
         std_move (jnp.float32): standard deviation of the moves
-        key (jnp.ndarray): an array with shape (2,) representing a jax PRNG key
+        key (Array): an array with shape (2,) representing a jax PRNG key
 
     Returns:
-        (jnp.ndarray, jnp.ndarray): (new positions, new key split from previous)
+        (Array, Array): (new positions, new key split from previous)
     """
     key, subkey = jax.random.split(key)
     return positions + std_move * jax.random.normal(subkey, shape=positions.shape), key
 
 
 def metropolis_symmetric_acceptance(
-    amplitude: jnp.ndarray, proposed_amplitude: jnp.ndarray, logabs: bool = True
-) -> jnp.ndarray:
+    amplitude: Array, proposed_amplitude: Array, logabs: bool = True
+) -> Array:
     """Standard Metropolis acceptance ratio for a symmetric proposal function.
 
     The general Metropolis-Hastings choice of acceptance ratio for moves from state i to
@@ -262,16 +258,16 @@ def metropolis_symmetric_acceptance(
     refers to |psi(i)|^2.
 
     Args:
-        amplitude (jnp.ndarray): one-dimensional array of wavefunction amplitudes for
+        amplitude (Array): one-dimensional array of wavefunction amplitudes for
             the current state, or log wavefunction amplitudes if logabs is True
-        proposed_amplitude (jnp.ndarray): one-dimensional array of wavefunction
+        proposed_amplitude (Array): one-dimensional array of wavefunction
             amplitudes for the proposed state, or log wavefunction amplitudes if logabs
             is True
         logabs (bool, optional): whether the provided amplitudes represent psi
             (logabs = False) or log|psi| (logabs = True). Defaults to True.
 
     Returns:
-        jnp.ndarray: one-dimensional array of acceptance ratios for the Metropolis
+        Array: one-dimensional array of acceptance ratios for the Metropolis
         algorithm
     """
     if not logabs:

--- a/vmcnet/mcmc/position_amplitude_core.py
+++ b/vmcnet/mcmc/position_amplitude_core.py
@@ -9,7 +9,7 @@ from vmcnet.utils.distribute import (
     replicate_all_local_devices,
     default_distribute_data,
 )
-from vmcnet.utils.typing import P, M, ModelApply
+from vmcnet.utils.typing import Array, P, M, ModelApply
 
 
 class PositionAmplitudeWalkerData(TypedDict):
@@ -22,12 +22,12 @@ class PositionAmplitudeWalkerData(TypedDict):
     more dimensions.
 
     Attributes:
-        position (jnp.ndarray): array of shape (n, ...)
-        amplitude (jnp.ndarray): array of shape (n,)
+        position (Array): array of shape (n, ...)
+        amplitude (Array): array of shape (n,)
     """
 
-    position: jnp.ndarray
-    amplitude: jnp.ndarray
+    position: Array
+    amplitude: Array
 
 
 class PositionAmplitudeData(TypedDict):
@@ -47,14 +47,12 @@ class PositionAmplitudeData(TypedDict):
     move_metadata: Any
 
 
-def make_position_amplitude_data(
-    position: jnp.ndarray, amplitude: jnp.ndarray, move_metadata: Any
-):
+def make_position_amplitude_data(position: Array, amplitude: Array, move_metadata: Any):
     """Create PositionAmplitudeData from position, amplitude, and move_metadata.
 
     Args:
-        position (jnp.ndarray): the particle positions
-        amplitude (jnp.ndarray): the wavefunction amplitudes
+        position (Array): the particle positions
+        amplitude (Array): the wavefunction amplitudes
         move_metadata (Any): other required metadata for the metropolis algorithm
 
     Returns:
@@ -66,31 +64,31 @@ def make_position_amplitude_data(
     )
 
 
-def get_position_from_data(data: PositionAmplitudeData) -> jnp.ndarray:
+def get_position_from_data(data: PositionAmplitudeData) -> Array:
     """Get the position data from PositionAmplitudeData.
 
     Args:
         data (PositionAmplitudeData): the data
 
     Returns:
-        jnp.ndarray: the particle positions from the data
+        Array: the particle positions from the data
     """
     return data["walker_data"]["position"]
 
 
-def get_amplitude_from_data(data: PositionAmplitudeData) -> jnp.ndarray:
+def get_amplitude_from_data(data: PositionAmplitudeData) -> Array:
     """Get the amplitude data from PositionAmplitudeData.
 
     Args:
         data (PositionAmplitudeData): the data
 
     Returns:
-        jnp.ndarray: the wave function amplitudes from the data
+        Array: the wave function amplitudes from the data
     """
     return data["walker_data"]["amplitude"]
 
 
-def to_pam_tuple(data: PositionAmplitudeData) -> Tuple[jnp.ndarray, jnp.ndarray, Any]:
+def to_pam_tuple(data: PositionAmplitudeData) -> Tuple[Array, Array, Any]:
     """Returns data as a (position, amplitude, move_metadata) tuple.
 
     Useful for quickly assigning all three pieces to local variables for further use.
@@ -123,10 +121,7 @@ def distribute_position_amplitude_data(
 def make_position_amplitude_gaussian_proposal(
     model_apply: ModelApply[P],
     get_std_move: Callable[[PositionAmplitudeData], jnp.float32],
-) -> Callable[
-    [P, PositionAmplitudeData, jnp.ndarray],
-    Tuple[PositionAmplitudeData, jnp.ndarray],
-]:
+) -> Callable[[P, PositionAmplitudeData, Array], Tuple[PositionAmplitudeData, Array]]:
     """Create a gaussian proposal fn on PositionAmplitudeData.
 
     Positions are perturbed by a guassian; amplitudes are evaluated using the supplied
@@ -162,7 +157,7 @@ def make_position_amplitude_gaussian_proposal(
 
 def make_position_amplitude_metropolis_symmetric_acceptance(
     logabs: bool = True,
-) -> Callable[[P, PositionAmplitudeData, PositionAmplitudeData], jnp.ndarray]:
+) -> Callable[[P, PositionAmplitudeData, PositionAmplitudeData], Array]:
     """Create a Metropolis acceptance function on PositionAmplitudeData.
 
     Args:
@@ -189,12 +184,12 @@ def make_position_amplitude_metropolis_symmetric_acceptance(
 
 
 def make_position_amplitude_update(
-    update_move_metadata_fn: Optional[Callable[[M, jnp.ndarray], M]] = None
+    update_move_metadata_fn: Optional[Callable[[M, Array], M]] = None
 ) -> Callable[
     [
         PositionAmplitudeData,
         PositionAmplitudeData,
-        jnp.ndarray,
+        Array,
     ],
     PositionAmplitudeData,
 ]:
@@ -206,7 +201,7 @@ def make_position_amplitude_update(
     `adjust_std_move_fn`.
 
     The moves in `move_mask` are applied along the first axis of the position data, and
-    should be the same shape as the amplitude data (one-dimensional jnp.ndarray).
+    should be the same shape as the amplitude data (one-dimensional Array).
 
     Args:
         update_move_metadata_fn (Callable): function which calculates the new
@@ -214,7 +209,7 @@ def make_position_amplitude_update(
 
     Returns:
         Callable: function with signature
-            (PositionAmplitudeData, PositionAmplitudeData, jnp.ndarray) ->
+            (PositionAmplitudeData, PositionAmplitudeData, Array) ->
                 (PositionAmplitudeData),
             which takes in the original PositionAmplitudeData, the proposed
             PositionAmplitudeData, and a move mask. Uses
@@ -224,9 +219,9 @@ def make_position_amplitude_update(
     def update_position_amplitude(
         data: PositionAmplitudeData,
         proposed_data: PositionAmplitudeData,
-        move_mask: jnp.ndarray,
+        move_mask: Array,
     ) -> PositionAmplitudeData:
-        def mask_on_first_dimension(old_data: jnp.ndarray, proposal: jnp.ndarray):
+        def mask_on_first_dimension(old_data: Array, proposal: Array):
             shaped_mask = jnp.reshape(move_mask, (-1, *((1,) * (old_data.ndim - 1))))
             return jnp.where(shaped_mask, proposal, old_data)
 
@@ -250,7 +245,7 @@ def make_position_amplitude_update(
 def make_position_amplitude_gaussian_metropolis_step(
     model_apply: ModelApply[P],
     get_std_move: Callable[[PositionAmplitudeData], jnp.float32],
-    update_move_metadata_fn: Optional[Callable[[M, jnp.ndarray], M]] = None,
+    update_move_metadata_fn: Optional[Callable[[M, Array], M]] = None,
     logabs: bool = True,
 ) -> metropolis.MetropolisStep[P, PositionAmplitudeData]:
     """Make a gaussian proposal with Metropolis acceptance for PositionAmplitudeData.

--- a/vmcnet/mcmc/simple_position_amplitude.py
+++ b/vmcnet/mcmc/simple_position_amplitude.py
@@ -10,7 +10,7 @@ from .position_amplitude_core import (
     make_position_amplitude_gaussian_metropolis_step,
     PositionAmplitudeWalkerData,
 )
-from vmcnet.utils.typing import P, ModelApply
+from vmcnet.utils.typing import Array, P, ModelApply
 
 
 class SimplePositionAmplitudeData(TypedDict):
@@ -23,14 +23,12 @@ class SimplePositionAmplitudeData(TypedDict):
 SPAData = SimplePositionAmplitudeData
 
 
-def make_simple_position_amplitude_data(
-    position: jnp.ndarray, amplitude: jnp.ndarray
-) -> SPAData:
+def make_simple_position_amplitude_data(position: Array, amplitude: Array) -> SPAData:
     """Create SimplePositionAmplitudeData from position and amplitude.
 
     Args:
-        position (jnp.ndarray): the particle positions
-        amplitude (jnp.ndarray): the wavefunction amplitudes
+        position (Array): the particle positions
+        amplitude (Array): the wavefunction amplitudes
 
     Returns:
         SPAData

--- a/vmcnet/models/invariance.py
+++ b/vmcnet/models/invariance.py
@@ -5,7 +5,7 @@ from typing import Iterable, Optional, Sequence
 import flax
 import jax.numpy as jnp
 
-from vmcnet.utils.typing import ArrayList, Backflow, ParticleSplit
+from vmcnet.utils.typing import Array, ArrayList, Backflow, ParticleSplit
 from .core import Dense, _split_mean, get_nsplits
 from .weights import WeightInitializer
 
@@ -28,9 +28,9 @@ class SplitMeanDense(flax.linen.Module):
             This determines the output shapes for each split, i.e. the outputs are
             shaped (..., split_size[i], ndense[i])
         kernel_initializer (WeightInitializer): kernel initializer. Has signature
-            (key, shape, dtype) -> jnp.ndarray
+            (key, shape, dtype) -> Array
         bias_initializer (WeightInitializer): bias initializer. Has signature
-            (key, shape, dtype) -> jnp.ndarray
+            (key, shape, dtype) -> Array
         use_bias (bool, optional): whether to add a bias term. Defaults to True.
         register_kfac (bool, optional): whether to register the dense computations with
             KFAC. Defaults to True.
@@ -65,11 +65,11 @@ class SplitMeanDense(flax.linen.Module):
             for i in range(nspins)
         ]
 
-    def __call__(self, x: jnp.ndarray) -> ArrayList:
+    def __call__(self, x: Array) -> ArrayList:
         """Split the input and apply a dense layer to each split.
 
         Args:
-            x (jnp.ndarray): array of shape (..., n, d)
+            x (Array): array of shape (..., n, d)
 
         Returns:
             [(..., self.ndense_per_spin[i])]: list of length nsplits, where nsplits
@@ -111,9 +111,9 @@ class InvariantTensor(flax.linen.Module):
             ) -> stream_1e of shape (..., n, d').
             Can pass None here to only apply SplitMeanDense followed by reshaping.
         kernel_initializer (WeightInitializer): kernel initializer for the dense
-            layer(s). Has signature (key, shape, dtype) -> jnp.ndarray
+            layer(s). Has signature (key, shape, dtype) -> Array
         bias_initializer (WeightInitializer): bias initializer for the dense layer(s).
-            Has signature (key, shape, dtype) -> jnp.ndarray
+            Has signature (key, shape, dtype) -> Array
         use_bias (bool, optional): whether to add a bias term. Defaults to True.
         register_kfac (bool, optional): whether to register the dense computations with
             KFAC. Defaults to True.
@@ -146,20 +146,20 @@ class InvariantTensor(flax.linen.Module):
             math.prod(shape) for shape in self.output_shape_per_split
         ]
 
-    def _reshape_dense_outputs(self, dense_out: jnp.ndarray, i: int):
+    def _reshape_dense_outputs(self, dense_out: Array, i: int):
         output_shape = dense_out.shape[:-1] + tuple(self.output_shape_per_split[i])
         return jnp.reshape(dense_out, output_shape)
 
     @flax.linen.compact
     def __call__(
-        self, stream_1e: jnp.ndarray, stream_2e: Optional[jnp.ndarray] = None
+        self, stream_1e: Array, stream_2e: Optional[Array] = None
     ) -> ArrayList:
         """Backflow -> split mean dense to get invariance -> reshape.
 
         Args:
-            stream_1e (jnp.ndarray): one-electron input stream of shape
+            stream_1e (Array): one-electron input stream of shape
                 (..., nelec, d1).
-            stream_2e (jnp.ndarray, optional): two-electron input of shape
+            stream_2e (Array, optional): two-electron input of shape
                 (..., nelec, nelec, d2).
 
         Returns:

--- a/vmcnet/models/weights.py
+++ b/vmcnet/models/weights.py
@@ -19,10 +19,12 @@ from jax.nn.initializers import (
 )
 from ml_collections import ConfigDict
 
+from vmcnet.utils.typing import Array
+
 Key = Any
 Shape = Iterable[int]
 Dtype = Any
-WeightInitializer = Callable[[Key, Shape, Dtype], jnp.ndarray]
+WeightInitializer = Callable[[Key, Shape, Dtype], Array]
 
 INITIALIZER_CONSTRUCTORS: Dict[str, Callable] = {
     "zeros": lambda dtype=jnp.float32: functools.partial(zeros, dtype=dtype),

--- a/vmcnet/physics/core.py
+++ b/vmcnet/physics/core.py
@@ -6,24 +6,22 @@ import jax.numpy as jnp
 from kfac_ferminet_alpha import loss_functions
 
 import vmcnet.utils as utils
-from vmcnet.utils.typing import P, ModelApply
+from vmcnet.utils.typing import Array, P, ModelApply
 
-EnergyAuxData = Tuple[
-    jnp.float32, jnp.ndarray, Optional[jnp.float32], Optional[jnp.float32]
-]
+EnergyAuxData = Tuple[jnp.float32, Array, Optional[jnp.float32], Optional[jnp.float32]]
 EnergyData = Tuple[jnp.float32, EnergyAuxData]
-ValueGradEnergyFn = Callable[[P, jnp.ndarray], Tuple[EnergyData, P]]
+ValueGradEnergyFn = Callable[[P, Array], Tuple[EnergyData, P]]
 
 
 def initialize_molecular_pos(
-    key: jnp.ndarray,
+    key: Array,
     nchains: int,
-    ion_pos: jnp.ndarray,
-    ion_charges: jnp.ndarray,
+    ion_pos: Array,
+    ion_charges: Array,
     nelec_total: int,
     init_width: float = 1.0,
     dtype=jnp.float32,
-) -> Tuple[jnp.ndarray, jnp.ndarray]:
+) -> Tuple[Array, Array]:
     """Initialize a set of plausible initial electron positions.
 
     For each chain, each electron is assigned to a random ion and then its position is
@@ -74,10 +72,10 @@ def combine_local_energy_terms(
         (params, x) -> local energy array of shape (x.shape[0],)
     """
 
-    def local_energy_fn(params: P, x: jnp.ndarray) -> jnp.ndarray:
+    def local_energy_fn(params: P, x: Array) -> Array:
         local_energy_sum = local_energy_terms[0](params, x)
         for term in local_energy_terms[1:]:
-            local_energy_sum = cast(jnp.ndarray, local_energy_sum + term(params, x))
+            local_energy_sum = cast(Array, local_energy_sum + term(params, x))
         return local_energy_sum
 
     return local_energy_fn
@@ -86,7 +84,7 @@ def combine_local_energy_terms(
 def laplacian_psi_over_psi(
     grad_log_psi_apply: ModelApply,
     params: P,
-    x: jnp.ndarray,
+    x: Array,
 ) -> jnp.float32:
     """Compute (nabla^2 psi) / psi at x given a function which evaluates psi'(x)/psi.
 
@@ -118,7 +116,7 @@ def laplacian_psi_over_psi(
             signature (params, x) -> (nabla psi)(x) / psi(x), so the derivative should
             be over the second arg, x, and the output shape should be the same as x
         params (pytree): model parameters, passed as the first arg of grad_log_psi
-        x (jnp.ndarray): second input to grad_log_psi
+        x (Array): second input to grad_log_psi
 
     Returns:
         jnp.float32: "local" laplacian calculation, i.e. (nabla^2 psi) / psi
@@ -146,12 +144,12 @@ def laplacian_psi_over_psi(
 
 
 def get_statistics_from_local_energy(
-    local_energies: jnp.ndarray, nchains: int, nan_safe: bool = True
+    local_energies: Array, nchains: int, nan_safe: bool = True
 ) -> Tuple[jnp.float32, jnp.float32]:
     """Collectively reduce local energies to an average energy and variance.
 
     Args:
-        local_energies (jnp.ndarray): local energies of shape (nchains,), possibly
+        local_energies (Array): local energies of shape (nchains,), possibly
             distributed across multiple devices via utils.distribute.pmap.
         nchains (int): total number of chains across all devices, used to compute a
             sample variance estimate of the local energy
@@ -178,7 +176,7 @@ def get_statistics_from_local_energy(
 
 def get_default_energy_bwd(
     log_psi_apply: ModelApply[P],
-    mean_grad_fn: Callable[[jnp.ndarray], jnp.ndarray],
+    mean_grad_fn: Callable[[Array], Array],
 ):
     """Use a standard variance reduction formula to get the bwd pass of the energy.
 
@@ -201,7 +199,7 @@ def get_default_energy_bwd(
     """
 
     def scaled_by_local_e(
-        params: P, positions: jnp.ndarray, centered_local_energies: jnp.ndarray
+        params: P, positions: Array, centered_local_energies: Array
     ) -> jnp.float32:
         log_psi = log_psi_apply(params, positions)
         loss_functions.register_normal_predictive_distribution(log_psi[:, None])
@@ -222,7 +220,7 @@ def create_value_and_grad_energy_fn(
     log_psi_apply: ModelApply[P],
     local_energy_fn: ModelApply[P],
     nchains: int,
-    clipping_fn: Optional[Callable[[jnp.ndarray], jnp.ndarray]] = None,
+    clipping_fn: Optional[Callable[[Array], Array]] = None,
     nan_safe: bool = True,
     get_energy_bwd: Callable = get_default_energy_bwd,
 ) -> ValueGradEnergyFn[P]:
@@ -268,7 +266,7 @@ def create_value_and_grad_energy_fn(
     """
 
     @jax.custom_vjp
-    def compute_energy_data(params: P, positions: jnp.ndarray) -> EnergyData:
+    def compute_energy_data(params: P, positions: Array) -> EnergyData:
         local_energies_noclip = local_energy_fn(params, positions)
         if clipping_fn is not None:
             local_energies = clipping_fn(local_energies_noclip)
@@ -299,7 +297,7 @@ def create_value_and_grad_energy_fn(
             aux_data = (variance, local_energies, energy_noclip, variance_noclip)
         return energy, aux_data
 
-    def energy_fwd(params: P, positions: jnp.ndarray):
+    def energy_fwd(params: P, positions: Array):
         output = compute_energy_data(params, positions)
         energy = output[0]
         local_energies = output[1][1]

--- a/vmcnet/physics/kinetic.py
+++ b/vmcnet/physics/kinetic.py
@@ -5,11 +5,11 @@ import jax
 import jax.numpy as jnp
 
 import vmcnet.physics as physics
-from vmcnet.utils.typing import P, ModelApply
+from vmcnet.utils.typing import Array, P, ModelApply
 
 
 def create_continuous_kinetic_energy(
-    log_psi_apply: Callable[[P, jnp.ndarray], Union[jnp.float32, jnp.ndarray]]
+    log_psi_apply: Callable[[P, Array], Union[jnp.float32, Array]]
 ) -> ModelApply[P]:
     """Create the local kinetic energy fn (params, x) -> -0.5 (nabla^2 psi(x) / psi(x)).
 
@@ -27,7 +27,7 @@ def create_continuous_kinetic_energy(
     """
     grad_log_psi_apply = jax.grad(log_psi_apply, argnums=1)
 
-    def kinetic_energy_fn(params: P, x: jnp.ndarray) -> jnp.float32:
+    def kinetic_energy_fn(params: P, x: Array) -> jnp.float32:
         return -0.5 * physics.core.laplacian_psi_over_psi(grad_log_psi_apply, params, x)
 
     return jax.vmap(kinetic_energy_fn, in_axes=(None, 0), out_axes=0)

--- a/vmcnet/physics/potential.py
+++ b/vmcnet/physics/potential.py
@@ -2,29 +2,29 @@
 from typing import Tuple
 import jax.numpy as jnp
 
-from vmcnet.utils.typing import ModelApply, ModelParams
+from vmcnet.utils.typing import Array, ModelApply, ModelParams
 
 
-def _compute_displacements(x: jnp.ndarray, y: jnp.ndarray) -> jnp.ndarray:
+def _compute_displacements(x: Array, y: Array) -> Array:
     """Compute the pairwise displacements between x and y in the second-to-last dim.
 
     Args:
-        x (jnp.ndarray): array of shape (..., n_x, d)
-        y (jnp.ndarray): array of shape (..., n_y, d)
+        x (Array): array of shape (..., n_x, d)
+        y (Array): array of shape (..., n_y, d)
 
     Returns:
-        jnp.ndarray: pairwise displacements (x_i - y_j), with shape (..., n_x, n_y, d)
+        Array: pairwise displacements (x_i - y_j), with shape (..., n_x, n_y, d)
     """
     return jnp.expand_dims(x, axis=-2) - jnp.expand_dims(y, axis=-3)
 
 
 def _compute_soft_norm(
-    displacements: jnp.ndarray, softening_term: jnp.float32 = 0.0
-) -> jnp.ndarray:
+    displacements: Array, softening_term: jnp.float32 = 0.0
+) -> Array:
     """Compute an (optionally softened) norm, sqrt((sum_i x_i^2) + softening_term^2).
 
     Args:
-        displacements (jnp.ndarray): array of shape (..., d)
+        displacements (Array): array of shape (..., d)
         softening_term (jnp.float32, optional): this amount squared is added to
             sum_i x_i^2 before taking the sqrt. The smaller this term, the closer the
             derivative gets to a step function (but the derivative is continuous except
@@ -32,16 +32,14 @@ def _compute_soft_norm(
             vector 2-norm. Defaults to 0.0.
 
     Returns:
-        jnp.ndarray: array with shape displacements.shape[:-1]
+        Array: array with shape displacements.shape[:-1]
     """
     return jnp.sqrt(
         jnp.sum(jnp.square(displacements), axis=-1) + jnp.square(softening_term)
     )
 
 
-def _get_ion_ion_info(
-    ion_locations: jnp.ndarray, ion_charges: jnp.ndarray
-) -> Tuple[jnp.ndarray, jnp.ndarray]:
+def _get_ion_ion_info(ion_locations: Array, ion_charges: Array) -> Tuple[Array, Array]:
     """Get pairwise ion-ion displacements and charge-charge products."""
     ion_ion_displacements = _compute_displacements(ion_locations, ion_locations)
     charge_charge_prods = jnp.expand_dims(ion_charges, axis=-1) * ion_charges
@@ -49,17 +47,17 @@ def _get_ion_ion_info(
 
 
 def create_electron_ion_coulomb_potential(
-    ion_locations: jnp.ndarray,
-    ion_charges: jnp.ndarray,
+    ion_locations: Array,
+    ion_charges: Array,
     strength: jnp.float32 = 1.0,
     softening_term: jnp.float32 = 0.0,
 ) -> ModelApply[ModelParams]:
     """Computes the total coulomb potential attraction between electron and ion.
 
     Args:
-        ion_locations (jnp.ndarray): an (n, d) array of ion positions, where n is the
+        ion_locations (Array): an (n, d) array of ion positions, where n is the
             number of ion positions and d is the dimension of the space they live in
-        ion_charges (jnp.ndarray): an (n,) array of ion charges, in units of one
+        ion_charges (Array): an (n,) array of ion charges, in units of one
             elementary charge (the charge of one electron)
         strength (jnp.float32, optional): amount to multiply the overall interaction by.
             Defaults to 1.0.
@@ -74,7 +72,7 @@ def create_electron_ion_coulomb_potential(
         -> array of potential energies of shape electron_positions.shape[:-2]
     """
 
-    def potential_fn(params: ModelParams, x: jnp.ndarray) -> jnp.ndarray:
+    def potential_fn(params: ModelParams, x: Array) -> Array:
         del params
         electron_ion_displacements = _compute_displacements(x, ion_locations)
         electron_ion_distances = _compute_soft_norm(
@@ -105,7 +103,7 @@ def create_electron_electron_coulomb_potential(
         -> array of potential energies of shape electron_positions.shape[:-2]
     """
 
-    def potential_fn(params: ModelParams, x: jnp.ndarray) -> jnp.ndarray:
+    def potential_fn(params: ModelParams, x: Array) -> Array:
         del params
         electron_electron_displacements = _compute_displacements(x, x)
         electron_electron_distances = _compute_soft_norm(
@@ -119,14 +117,14 @@ def create_electron_electron_coulomb_potential(
 
 
 def create_ion_ion_coulomb_potential(
-    ion_locations: jnp.ndarray, ion_charges: jnp.ndarray
+    ion_locations: Array, ion_charges: Array
 ) -> ModelApply[ModelParams]:
     """Computes the total coulomb potential repulsion between stationary ions.
 
     Args:
-        ion_locations (jnp.ndarray): an (n, d) array of ion positions, where n is the
+        ion_locations (Array): an (n, d) array of ion positions, where n is the
             number of ion positions and d is the dimension of the space they live in
-        ion_charges (jnp.ndarray): an (n,) array of ion charges, in units of one
+        ion_charges (Array): an (n,) array of ion charges, in units of one
             elementary charge (the charge of one electron)
 
     Returns:
@@ -143,7 +141,7 @@ def create_ion_ion_coulomb_potential(
         jnp.triu(charge_charge_prods / ion_ion_distances, k=1), axis=(-1, -2)
     )
 
-    def potential_fn(params: ModelParams, x: jnp.ndarray) -> jnp.ndarray:
+    def potential_fn(params: ModelParams, x: Array) -> Array:
         del params, x
         return constant_potential
 

--- a/vmcnet/train/vmc.py
+++ b/vmcnet/train/vmc.py
@@ -1,13 +1,11 @@
 """Main VMC loop."""
 from typing import Tuple, Optional
 
-import jax.numpy as jnp
-
 from vmcnet.mcmc.metropolis import WalkerFn
 from vmcnet.updates.params import UpdateParamFn
 from vmcnet.utils.checkpoint import CheckpointWriter, MetricsWriter
 import vmcnet.utils as utils
-from vmcnet.utils.typing import D, GetAmplitudeFromData, P, S
+from vmcnet.utils.typing import Array, D, GetAmplitudeFromData, P, S
 
 
 def vmc_loop(
@@ -18,7 +16,7 @@ def vmc_loop(
     nepochs: int,
     walker_fn: WalkerFn[P, D],
     update_param_fn: UpdateParamFn[P, D, S],
-    key: jnp.ndarray,
+    key: Array,
     logdir: str = None,
     checkpoint_every: Optional[int] = 1000,
     best_checkpoint_every: Optional[int] = 100,
@@ -29,7 +27,7 @@ def vmc_loop(
     record_amplitudes: bool = False,
     get_amplitude_fn: Optional[GetAmplitudeFromData[D]] = None,
     nhistory_max: int = 200,
-) -> Tuple[P, S, D, jnp.ndarray]:
+) -> Tuple[P, S, D, Array]:
     """Main Variational Monte Carlo loop routine.
 
     Variational Monte Carlo (VMC) can be generically viewed as minimizing a
@@ -54,7 +52,7 @@ def vmc_loop(
                 -> (new_params, optimizer_state, dict: metrics, key).
             If metrics is not None, it is required to have the entries "energy" and
             "variance" at a minimum. If metrics is None, no checkpointing is done.
-        key (jnp.ndarray): an array with shape (2,) representing a jax PRNG key passed
+        key (Array): an array with shape (2,) representing a jax PRNG key passed
             to proposal_fn and used to randomly accept proposals with probabilities
             output by acceptance_fn
         logdir (str, optional): name of parent log directory. If None, no checkpointing

--- a/vmcnet/updates/params.py
+++ b/vmcnet/updates/params.py
@@ -14,6 +14,7 @@ from vmcnet.utils.pytree_helpers import (
     tree_reduce_l1,
 )
 from vmcnet.utils.typing import (
+    Array,
     D,
     GetPositionFromData,
     ModelApply,
@@ -23,7 +24,7 @@ from vmcnet.utils.typing import (
     S,
 )
 
-UpdateParamFn = Callable[[P, D, S, jnp.ndarray], Tuple[P, S, Dict, jnp.ndarray]]
+UpdateParamFn = Callable[[P, D, S, Array], Tuple[P, S, Dict, Array]]
 
 
 def _update_metrics_with_noclip(
@@ -121,7 +122,7 @@ def create_grad_energy_update_param_fn(
 
 def _get_traced_compute_param_norm(
     apply_pmap: bool = True,
-) -> Callable[[PyTree], jnp.ndarray]:
+) -> Callable[[PyTree], Array]:
     if not apply_pmap:
         return jax.jit(tree_reduce_l1)
 
@@ -141,7 +142,7 @@ def create_kfac_update_param_fn(
             kfac_ferminet_alpha
         damping (jnp.float32): damping coefficient
         get_position_fn (GetPositionFromData): function which gets the walker positions
-            from the data. Has signature data -> jnp.ndarray
+            from the data. Has signature data -> Array
 
     Returns:
         Callable: function which updates the parameters given the current data, params,

--- a/vmcnet/updates/parse_config.py
+++ b/vmcnet/updates/parse_config.py
@@ -10,7 +10,14 @@ from ml_collections import ConfigDict
 import vmcnet.mcmc.position_amplitude_core as pacore
 import vmcnet.physics as physics
 import vmcnet.utils as utils
-from vmcnet.utils.typing import D, GetPositionFromData, ModelApply, OptimizerState, P
+from vmcnet.utils.typing import (
+    Array,
+    D,
+    GetPositionFromData,
+    ModelApply,
+    OptimizerState,
+    P,
+)
 
 from .params import (
     UpdateParamFn,
@@ -53,9 +60,9 @@ def get_update_fn_and_init_optimizer(
     data: D,
     get_position_fn: GetPositionFromData[D],
     energy_data_val_and_grad: physics.core.ValueGradEnergyFn[P],
-    key: jnp.ndarray,
+    key: Array,
     apply_pmap: bool = True,
-) -> Tuple[UpdateParamFn[P, D, OptimizerState], OptimizerState, jnp.ndarray]:
+) -> Tuple[UpdateParamFn[P, D, OptimizerState], OptimizerState, Array]:
     """Get an update function and initialize optimizer state from the vmc configuration.
 
     Args:
@@ -71,7 +78,7 @@ def get_update_fn_and_init_optimizer(
                 -> ((expected_energy, auxiliary_energy_data), grad_energy),
             where auxiliary_energy_data is the tuple
             (expected_variance, local_energies, unclipped_energy, unclipped_variance)
-        key (jnp.ndarray): PRNGKey with which to initialize optimizer state
+        key (Array): PRNGKey with which to initialize optimizer state
         apply_pmap (bool, optional): whether to pmap the optimizer steps. Defaults to
             True.
 
@@ -80,7 +87,7 @@ def get_update_fn_and_init_optimizer(
         SGD, and SR (with either Adam or SGD) is supported.
 
     Returns:
-        (UpdateParamFn, OptimizerState, jnp.ndarray):
+        (UpdateParamFn, OptimizerState, Array):
         update param function with signature
             (params, data, optimizer_state, key)
             -> (new params, new state, metrics, new key),
@@ -152,12 +159,12 @@ def get_kfac_update_fn_and_state(
     data: D,
     get_position_fn: GetPositionFromData[D],
     energy_data_val_and_grad: physics.core.ValueGradEnergyFn[P],
-    key: jnp.ndarray,
+    key: Array,
     learning_rate_schedule: Callable[[int], jnp.float32],
     optimizer_config: ConfigDict,
     record_param_l1_norm: bool = False,
     apply_pmap: bool = True,
-) -> Tuple[UpdateParamFn[P, D, kfac_opt.State], kfac_opt.State, jnp.ndarray]:
+) -> Tuple[UpdateParamFn[P, D, kfac_opt.State], kfac_opt.State, Array]:
     """Get an update param function, initial state, and key for KFAC.
 
     Args:
@@ -170,7 +177,7 @@ def get_kfac_update_fn_and_state(
                 -> ((expected_energy, auxiliary_energy_data), grad_energy),
             where auxiliary_energy_data is the tuple
             (expected_variance, local_energies, unclipped_energy, unclipped_variance)
-        key (jnp.ndarray): PRNGKey with which to initialize optimizer state
+        key (Array): PRNGKey with which to initialize optimizer state
         learning_rate_schedule (Callable): function which returns a learning rate from
             epoch number. Has signature epoch -> learning_rate
         optimizer_config (ConfigDict): configuration for KFAC
@@ -180,7 +187,7 @@ def get_kfac_update_fn_and_state(
             True.
 
     Returns:
-        (UpdateParamFn, kfac_opt.State, jnp.ndarray):
+        (UpdateParamFn, kfac_opt.State, Array):
         update param function with signature
             (params, data, optimizer_state, key)
             -> (new params, new state, metrics, new key),

--- a/vmcnet/utils/checkpoint.py
+++ b/vmcnet/utils/checkpoint.py
@@ -18,7 +18,7 @@ import jax.numpy as jnp
 
 import vmcnet.utils.distribute as distribute
 import vmcnet.utils.io as io
-from vmcnet.utils.typing import CheckpointData, D, GetAmplitudeFromData, P, S
+from vmcnet.utils.typing import Array, CheckpointData, D, GetAmplitudeFromData, P, S
 
 T = TypeVar("T")
 
@@ -153,10 +153,10 @@ class CheckpointWriter(ThreadedWriter[CheckpointData]):
 
             checkpoint_data (CheckpointData): checkpoint data which contains:
                 epoch (int): epoch at which checkpoint is being saved
-                data (pytree or jnp.ndarray): walker data to save
+                data (pytree or Array): walker data to save
                 params (pytree): model parameters to save
                 optimizer_state (pytree): optimizer state to save
-                key (jnp.ndarray): RNG key, used to reproduce exact behavior from
+                key (Array): RNG key, used to reproduce exact behavior from
                     checkpoint
         """
         io.save_vmc_state(directory, name, checkpoint_data)
@@ -317,7 +317,7 @@ def save_metrics_and_handle_checkpoints(
     optimizer_state: S,
     old_data: D,
     new_data: D,
-    key: jnp.ndarray,
+    key: Array,
     metrics: Dict,
     nchains: int,
     running_energy_and_variance: RunningEnergyVariance,
@@ -474,7 +474,7 @@ def track_and_save_best_checkpoint(
     old_params: P,
     optimizer_state: S,
     data: D,
-    key: jnp.ndarray,
+    key: Array,
     metrics: Dict,
     nchains: int,
     running_energy_and_variance: RunningEnergyVariance,
@@ -567,7 +567,7 @@ def save_metrics_and_regular_checkpoint(
     new_params: P,
     optimizer_state: S,
     data: D,
-    key: jnp.ndarray,
+    key: Array,
     metrics: Dict,
     logdir: str,
     checkpoint_writer: CheckpointWriter,

--- a/vmcnet/utils/kfac.py
+++ b/vmcnet/utils/kfac.py
@@ -7,11 +7,11 @@ Some names are slightly modified (e.g. repeated_dense -> batch_dense).
 """
 from typing import Mapping, Union
 
-import jax.numpy as jnp
-
 from kfac_ferminet_alpha import curvature_blocks as blocks
 from kfac_ferminet_alpha import layers_and_loss_tags as tags
 from kfac_ferminet_alpha import utils as kfac_utils
+
+from vmcnet.utils.typing import Array
 
 BATCH_DENSE_TAG_NAME = "batch_dense_tag"
 batch_dense_tag = tags.LayerTag(BATCH_DENSE_TAG_NAME, 1, 1)
@@ -30,7 +30,7 @@ def register_batch_dense(y, x, w, b):
 class BatchDenseBlock(blocks.DenseTwoKroneckerFactored):
     """Dense curvature block corresponding to inputs of shape (..., d)."""
 
-    def compute_extra_scale(self) -> jnp.ndarray:
+    def compute_extra_scale(self) -> Array:
         """Extra scale factor for the curvature block (relative to other blocks)."""
         (x_shape,) = self.inputs_shapes
         return kfac_utils.product(x_shape) // (x_shape[0] * x_shape[-1])
@@ -39,8 +39,8 @@ class BatchDenseBlock(blocks.DenseTwoKroneckerFactored):
         self,
         info: Mapping[str, blocks._Arrays],
         batch_size: int,
-        ema_old: Union[float, jnp.ndarray],
-        ema_new: Union[float, jnp.ndarray],
+        ema_old: Union[float, Array],
+        ema_new: Union[float, Array],
         pmap_axis_name: str,
     ) -> None:
         """Satsify kfac_ferminet_alpha's assumption that the inputs are 2d.

--- a/vmcnet/utils/log_linear_exp.py
+++ b/vmcnet/utils/log_linear_exp.py
@@ -3,14 +3,14 @@ from typing import Optional
 
 import jax.numpy as jnp
 
-from vmcnet.utils.typing import SLArray
+from vmcnet.utils.typing import Array, SLArray
 from vmcnet.utils.kfac import register_batch_dense
 
 
 def log_linear_exp(
-    signs: jnp.ndarray,
-    vals: jnp.ndarray,
-    weights: Optional[jnp.ndarray] = None,
+    signs: Array,
+    vals: Array,
+    weights: Optional[Array] = None,
     axis: int = 0,
     register_kfac: bool = True,
 ) -> SLArray:
@@ -29,11 +29,11 @@ def log_linear_exp(
     exp(val_i) is approximately 0 for all i.
 
     Args:
-        signs (jnp.ndarray): array of signs of the input x with shape (..., d, ...),
+        signs (Array): array of signs of the input x with shape (..., d, ...),
             where d is the size of the given axis
-        vals (jnp.ndarray): array of log|abs(x)| with shape (..., d, ...), where d is
+        vals (Array): array of log|abs(x)| with shape (..., d, ...), where d is
             the size of the given axis
-        weights (jnp.ndarray, optional): weights of a linear transformation to apply to
+        weights (Array, optional): weights of a linear transformation to apply to
             the given axis, with shape (d, d'). If not provided, a simple sum is taken
             instead, equivalent to (d, 1) weights equal to 1. Defaults to None.
         axis (int, optional): axis along which to take the sum and max. Defaults to 0.

--- a/vmcnet/utils/pytree_helpers.py
+++ b/vmcnet/utils/pytree_helpers.py
@@ -3,7 +3,7 @@ import jax
 import jax.numpy as jnp
 import jax.flatten_util
 
-from vmcnet.utils.typing import PyTree, T
+from vmcnet.utils.typing import Array, PyTree, T
 
 
 def tree_sum(tree1: T, tree2: T) -> T:
@@ -21,7 +21,7 @@ def multiply_tree_by_scalar(tree: T, scalar: jnp.float32) -> T:
     return jax.tree_map(lambda x: scalar * x, tree)
 
 
-def tree_inner_product(tree1: T, tree2: T) -> jnp.ndarray:
+def tree_inner_product(tree1: T, tree2: T) -> Array:
     """Inner product of two pytrees with the same structure."""
     leaf_inner_prods = jax.tree_map(lambda a, b: jnp.sum(a * b), tree1, tree2)
     return jnp.sum(jax.flatten_util.ravel_pytree(leaf_inner_prods)[0])

--- a/vmcnet/utils/slog_helpers.py
+++ b/vmcnet/utils/slog_helpers.py
@@ -3,14 +3,14 @@
 import jax.numpy as jnp
 
 from .log_linear_exp import log_linear_exp
-from .typing import SLArray, ArrayList, SLArrayList
+from .typing import Array, SLArray, ArrayList, SLArrayList
 
 
-def array_to_slog(x: jnp.ndarray) -> SLArray:
+def array_to_slog(x: Array) -> SLArray:
     """Converts a regular array into (sign, logabs) form.
 
     Args:
-        x (jnp.ndarray): input data.
+        x (Array): input data.
 
     Returns:
         (SLArray): data in form (sign(x), log(abs(x)))
@@ -18,7 +18,7 @@ def array_to_slog(x: jnp.ndarray) -> SLArray:
     return (jnp.sign(x), jnp.log(jnp.abs(x)))
 
 
-def array_from_slog(x: SLArray) -> jnp.ndarray:
+def array_from_slog(x: SLArray) -> Array:
     """Converts an slog data tuple into a regular array.
 
     Args:
@@ -26,7 +26,7 @@ def array_from_slog(x: SLArray) -> jnp.ndarray:
         (sign(z), log(abs(z))) for some z which represents the underlying data.
 
     Returns:
-        (jnp.ndarray): the data as a single, regular array. In other words, the z
+        (Array): the data as a single, regular array. In other words, the z
         such that x = (sign(z), log(abs(z)))
     """
     return x[0] * jnp.exp(x[1])

--- a/vmcnet/utils/typing.py
+++ b/vmcnet/utils/typing.py
@@ -11,6 +11,7 @@ import jax.numpy as jnp
 import kfac_ferminet_alpha.optimizer as kfac_opt
 import optax
 
+Array = jnp.ndarray
 
 # Currently using PyTree = Any just to improve readability in the code.
 # A pytree is a "tree-like structure built out of container-like Python objects": see
@@ -47,29 +48,25 @@ ModelParams = frozen_dict.FrozenDict
 #  3. The model parameters
 #  4. The optimizer state
 #  5. The RNG key
-CheckpointData = Tuple[int, D, P, S, jnp.ndarray]
+CheckpointData = Tuple[int, D, P, S, Array]
 
-ArrayList = List[jnp.ndarray]
+ArrayList = List[Array]
 
 # Single array in (sign, logabs) form
-SLArray = Tuple[jnp.ndarray, jnp.ndarray]
+SLArray = Tuple[Array, Array]
 
 SLArrayList = List[SLArray]
 
 ParticleSplit = Union[int, Sequence[int]]
 
-InputStreams = Tuple[
-    jnp.ndarray, Optional[jnp.ndarray], Optional[jnp.ndarray], Optional[jnp.ndarray]
-]
-ComputeInputStreams = Callable[[jnp.ndarray], InputStreams]
+InputStreams = Tuple[Array, Optional[Array], Optional[Array], Optional[Array]]
+ComputeInputStreams = Callable[[Array], InputStreams]
 
-Backflow = Callable[[jnp.ndarray, Optional[jnp.ndarray]], jnp.ndarray]
+Backflow = Callable[[Array, Optional[Array]], Array]
 
-Jastrow = Callable[
-    [jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray], jnp.ndarray
-]
+Jastrow = Callable[[Array, Array, Array, Array, Array], Array]
 
-ModelApply = Callable[[P, jnp.ndarray], jnp.ndarray]
+ModelApply = Callable[[P, Array], Array]
 
-GetPositionFromData = Callable[[D], jnp.ndarray]
+GetPositionFromData = Callable[[D], Array]
 GetAmplitudeFromData = GetPositionFromData[D]


### PR DESCRIPTION
This PR doesn't actually bump any versions of anything or make any changes to our typing; it just creates an Alias for jnp.ndarray called Array in the typing.py file, and makes everywhere reference that.

This is probably a nice change whatever route we go down to make newer versions of numpy work, and it's a lot of lines changed so I figured I'd get this in first to make the future changes which actually change things be readable. 

PTAL @jeffminlin 