### PR TITLE
fixing docstrings and using mkdocs + extensions

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+../CONTRIBUTING.md

--- a/docs/gen_api_ref.py
+++ b/docs/gen_api_ref.py
@@ -1,0 +1,40 @@
+"""Generate the API reference pages and mkdocs nav."""
+from pathlib import Path
+
+import mkdocs_gen_files
+
+# flax.linen.Module gives mkdocstrings problems, so we filter out anything
+# that explicitly subclasses it, as well as private methods (which is default)
+FILTER_OUT_MODULE = """    handler: python
+    selection:
+        filters:
+        - "!^_[^_]"
+        - "!Module"
+"""
+
+if __name__ == "<run_path>":
+    nav = mkdocs_gen_files.Nav()
+
+    # leave out __init__.py files
+    package_paths = Path("vmcnet").glob("**/[!__init__]*.py")
+
+    for path in sorted(package_paths):
+        module_path = path.relative_to("vmcnet").with_suffix("")
+        doc_path = path.relative_to("vmcnet").with_suffix(".md")
+        full_doc_path = Path("api", doc_path)  # get path of file to be created
+
+        parts = list(module_path.parts)
+        nav[parts] = doc_path  # append to navigation
+
+        with mkdocs_gen_files.open(full_doc_path, "w") as fd:
+            # put in mkdocstrings magic
+            ident = ".".join(("vmcnet",) + module_path.parts)
+            print("::: " + ident, file=fd)
+            if parts[-1] == "core":
+                print(FILTER_OUT_MODULE, file=fd)
+
+        mkdocs_gen_files.set_edit_path(full_doc_path, path)
+
+    # make the navigation file
+    with mkdocs_gen_files.open("api/api_nav.md", "w") as nav_file:
+        nav_file.writelines(nav.build_literate_nav())

--- a/docs/gen_api_ref.py
+++ b/docs/gen_api_ref.py
@@ -9,7 +9,7 @@ FILTER_OUT_MODULE = """    handler: python
     selection:
         filters:
         - "!^_[^_]"
-        - "!Module"
+        - "!^Module$"
 """
 
 if __name__ == "<run_path>":

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+../README.md

--- a/docs/stylesheets/content.css
+++ b/docs/stylesheets/content.css
@@ -1,0 +1,3 @@
+.md-grid {
+    max-width: 75rem
+}

--- a/docs/stylesheets/docstrings.css
+++ b/docs/stylesheets/docstrings.css
@@ -1,0 +1,6 @@
+div.doc-object:not(.doc-module) {
+    padding-left: 25px;
+    padding-right: 25px;
+    border: 4px solid rgba(200, 200, 200);
+    margin-bottom: 100px;
+}

--- a/docs/stylesheets/sidebar.css
+++ b/docs/stylesheets/sidebar.css
@@ -1,0 +1,3 @@
+div.md-sidebar__scrollwrap {
+    overflow-x: auto
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,66 @@
+site_name: vmcnet
+repo_url: https://github.com/jeffminlin/vmcnet
+repo_name: jeffminlin/vmcnet
+edit_uri: ""
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: deep-purple
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: Switch to dark mode
+    - scheme: slate
+      primary: deep-purple
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.tracking
+
+plugins:
+  - search
+  - mkdocstrings:
+      watch:
+        - vmcnet
+      handlers:
+        python:
+          selection:
+            inherited_members: False
+          rendering:
+            heading_level: 3
+            members_order: source
+            show_root_heading: False
+            show_root_full_path: False
+            show_object_full_path: False
+            show_category_heading: False
+  - mike
+  - gen-files:
+      scripts:
+        - docs/gen_api_ref.py
+  - literate-nav:
+      nav_file: api_nav.md
+
+markdown_extensions:
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - pymdownx.snippets
+
+nav:
+  - Home: index.md
+  - API Reference: api/
+  - Contributing: CONTRIBUTING.md
+
+extra:
+  version:
+    provider: mike
+
+extra_css:
+  - stylesheets/docstrings.css
+  - stylesheets/sidebar.css
+  - stylesheets/content.css

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ testing =
     pytest>=6.0
     pytest-mock>=3.6
     pytest-cov>=2.0
-    mypy>=0.910
+    mypy==0.910
     flake8>=3.9
     pydocstyle[toml]>=6.1
     tox>=3.24

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,13 @@ testing =
     flake8>=3.9
     pydocstyle[toml]>=6.1
     tox>=3.24
+doc-gen = 
+    mkdocs==1.2.3
+    mkdocs-gen-files==0.3.3
+    mkdocs-literate-nav==0.4.0
+    mkdocs-material==8.0.5
+    mkdocstrings==0.16.2
+    mike==1.1.2
 
 [options.package_data]
 vmcnet = py.typed

--- a/vmcnet/mcmc/dynamic_width_position_amplitude.py
+++ b/vmcnet/mcmc/dynamic_width_position_amplitude.py
@@ -91,11 +91,11 @@ def make_threshold_adjust_std_move(
     Args:
         target_acceptance_prob (jnp.float32): target value for the average acceptance
             ratio. Defaults to 0.5.
-        accept_ratio_threshold_delta (jnp.float32): how far away from the target the
-            acceptance ratio must be to trigger a compensating update. Defaults to 0.1.
-        adjust_std_delta (jnp.float32): how big of an adjustment to make to the step
-            width. Adjustments will multiply by either (1.0 + adjust_std_delta) or
-            (1.0 - adjust_std_delta). Defaults to 0.1.
+        threshold_delta (jnp.float32): how far away from the target the acceptance ratio
+            must be to trigger a compensating update. Defaults to 0.1.
+        adjustment_delta (jnp.float32): how big of an adjustment to make to the step
+            width. Adjustments will multiply by either (1.0 + adjustment_delta) or
+            (1.0 - adjustment_delta). Defaults to 0.1.
     """
 
     def adjust_std_move(

--- a/vmcnet/mcmc/position_amplitude_core.py
+++ b/vmcnet/mcmc/position_amplitude_core.py
@@ -56,7 +56,8 @@ def make_position_amplitude_data(position: Array, amplitude: Array, move_metadat
         move_metadata (Any): other required metadata for the metropolis algorithm
 
     Returns:
-        PositionAmplitudeData
+        PositionAmplitudeData: data containing positions, wavefn amplitudes, and move
+        metadata
     """
     return PositionAmplitudeData(
         walker_data=PositionAmplitudeWalkerData(position=position, amplitude=amplitude),
@@ -133,8 +134,8 @@ def make_position_amplitude_gaussian_proposal(
         model_apply (Callable): function which evaluates a model. Has signature
             (params, position) -> amplitude
         get_std_move (Callable): function which gets the standard deviation of the
-        gaussian move, which can optionally depend on the data. Has signature
-        (PositionAmplitudeData) -> std_move
+            gaussian move, which can optionally depend on the data. Has signature
+            (PositionAmplitudeData) -> std_move
 
     Returns:
         Callable: proposal function which can be passed to the main VMC routine. Has
@@ -207,7 +208,8 @@ def make_position_amplitude_update(
 
     Args:
         update_move_metadata_fn (Callable): function which calculates the new
-        move_metadata. Has signature (old_move_metadata, move_mask) -> new_move_metadata
+            move_metadata. Has signature
+            (old_move_metadata, move_mask) -> new_move_metadata
 
     Returns:
         Callable: function with signature

--- a/vmcnet/models/antiequivariance.py
+++ b/vmcnet/models/antiequivariance.py
@@ -162,7 +162,7 @@ class OrbitalCofactorAntiequivarianceLayer(Module):
     """Apply a cofactor antiequivariance multiplicatively to equivariant inputs.
 
     Attributes:
-         spin_split (ParticleSplit): number of spins to split the input equally,
+        spin_split (ParticleSplit): number of spins to split the input equally,
             or specified sequence of locations to split along the 2nd-to-last axis.
             E.g., if nelec = 10, and `spin_split` = 2, then the input is split (5, 5).
             If nelec = 10, and `spin_split` = (2, 4), then the input is split into
@@ -248,7 +248,7 @@ class SLogOrbitalCofactorAntiequivarianceLayer(Module):
     """Apply a cofactor antieq. multiplicatively to equivariant inputs with slog out.
 
     Attributes:
-         spin_split (ParticleSplit): number of spins to split the input equally,
+        spin_split (ParticleSplit): number of spins to split the input equally,
             or specified sequence of locations to split along the 2nd-to-last axis.
             E.g., if nelec = 10, and `spin_split` = 2, then the input is split (5, 5).
             If nelec = 10, and `spin_split` = (2, 4), then the input is split into
@@ -334,7 +334,7 @@ class PerParticleDeterminantAntiequivarianceLayer(Module):
     """Antieq. layer based on determinants of per-particle orbital matrices, slog out.
 
     Attributes:
-         spin_split (ParticleSplit): number of spins to split the input equally,
+        spin_split (ParticleSplit): number of spins to split the input equally,
             or specified sequence of locations to split along the 2nd-to-last axis.
             E.g., if nelec = 10, and `spin_split` = 2, then the input is split (5, 5).
             If nelec = 10, and `spin_split` = (2, 4), then the input is split into
@@ -419,7 +419,7 @@ class SLogPerParticleDeterminantAntiequivarianceLayer(Module):
     """Antieq. layer based on determinants of per-particle orbital matrices, slog out.
 
     Attributes:
-         spin_split (ParticleSplit): number of spins to split the input equally,
+        spin_split (ParticleSplit): number of spins to split the input equally,
             or specified sequence of locations to split along the 2nd-to-last axis.
             E.g., if nelec = 10, and `spin_split` = 2, then the input is split (5, 5).
             If nelec = 10, and `spin_split` = (2, 4), then the input is split into

--- a/vmcnet/models/construct.py
+++ b/vmcnet/models/construct.py
@@ -641,7 +641,7 @@ def get_resnet_determinant_fn_for_ferminet(
         activation (Activation): the activation function to use for the  resnet.
         kernel_initializer (WeightInitializer): kernel initializer for the resnet.
         bias_initializer (WeightInitializer): bias initializer for the resnet.
-        use_bias(bool): Whether to use a bias in the ResNet. Defaults to True.
+        use_bias (bool): Whether to use a bias in the ResNet. Defaults to True.
         register_kfac (bool): Whether to register the ResNet Dense layers with KFAC.
             Currently, params for this ResNet explode to huge values and cause nans
             if register_kfac is True, so this flag defaults to false and should only be

--- a/vmcnet/models/core.py
+++ b/vmcnet/models/core.py
@@ -39,7 +39,7 @@ def compute_ee_norm_with_safe_diag(r_ee):
     0 * norm(x - x + 1) along the diagonal.
 
     Args:
-        x (Array): electron-electron displacements wth shape (..., n, n, d)
+        r_ee (Array): electron-electron displacements wth shape (..., n, n, d)
 
     Returns:
         Array: electron-electrondists with shape (..., n, n, 1)
@@ -343,7 +343,6 @@ class LogDomainResNet(Module):
             SLArray -> SLArray (shape is preserved).
         kernel_init (WeightInitializer, optional): initializer function for the weight
             matrices of each layer. Defaults to orthogonal initialization.
-
         use_bias (bool, optional): whether the dense layers should all have bias terms
             or not. Defaults to True.
     """

--- a/vmcnet/updates/parse_config.py
+++ b/vmcnet/updates/parse_config.py
@@ -84,7 +84,7 @@ def get_update_fn_and_init_optimizer(
 
     Raises:
         ValueError: A non-supported optimizer type is requested. Currently, KFAC, Adam,
-        SGD, and SR (with either Adam or SGD) is supported.
+            SGD, and SR (with either Adam or SGD) is supported.
 
     Returns:
         (UpdateParamFn, OptimizerState, PRNGKey):
@@ -418,7 +418,7 @@ def get_sr_update_fn_and_state(
 
     Raises:
         ValueError: A non-supported descent type is requested. Currently only Adam and
-        SGD are supported.
+            SGD are supported.
 
     Returns:
         (UpdateParamFn, optax.OptState):

--- a/vmcnet/utils/slog_helpers.py
+++ b/vmcnet/utils/slog_helpers.py
@@ -23,7 +23,7 @@ def array_from_slog(x: SLArray) -> Array:
 
     Args:
         x (SLArray): input data in slog form. This data looks like
-        (sign(z), log(abs(z))) for some z which represents the underlying data.
+            (sign(z), log(abs(z))) for some z which represents the underlying data.
 
     Returns:
         (Array): the data as a single, regular array. In other words, the z


### PR DESCRIPTION
This PR adds auto-generation of web documentation to this repo, with the result deployed at https://jeffminlin.github.io/vmcnet.

This uses the mkdocs, mkdocs-material, mkdocstrings, mkdocs-gen-files, and mkdocs-literate-nav to generate the API reference, and symlinks README.md -> docs/index.md and CONTRIBUTING.md -> docs/CONTRIBUTING.md.

Several docstrings were fixed in terms of formatting here and there so that the docstring handlers could process everything, and `models.core.Module` had to be left out due to some unknown issue with directly subclassing `flax.linen.Module`.

Currently the documentation needs to be built locally and pushed in order to be updated. Incorporating the web documentation into the CI is left for a future PR.