### PR TITLE
add mean centering to clipping as default

### DIFF
--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -287,6 +287,7 @@ def get_default_vmc_config() -> Dict:
         "record_amplitudes": False,
         "record_param_l1_norm": False,
         "clip_threshold": 5.0,
+        "clip_center": "mean",  # mean or median
         "nan_safe": True,
         "optimizer_type": "kfac",
         "optimizer": {

--- a/vmcnet/utils/typing.py
+++ b/vmcnet/utils/typing.py
@@ -73,3 +73,5 @@ ModelApply = Callable[[P, Array], Array]
 
 GetPositionFromData = Callable[[D], Array]
 GetAmplitudeFromData = GetPositionFromData[D]
+
+ClippingFn = Callable[[Array, jnp.float32], Array]


### PR DESCRIPTION
We were getting nans with median centered clipping that seem to be at least partially resolved with mean centered clipping of the local energies. This PR allows for the choice at the command line, with the default set to mean-centered clipping.