### PR TITLE
add s^2 expectation calculation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ console_scripts =
 
 [options.extras_require]
 testing =
-    black>=21.5b1
+    black==22.1.0
     chex>=0.0.7
     pytest>=6.0
     pytest-mock>=3.6

--- a/tests/units/models/test_antisymmetry.py
+++ b/tests/units/models/test_antisymmetry.py
@@ -78,7 +78,7 @@ def _vandermonde_product(x):
 
 def _diagonal_product(flattened_square_matrix, n):
     """Get product of diagonal entries of a flattened square matrix."""
-    assert flattened_square_matrix.shape[-1] == n ** 2
+    assert flattened_square_matrix.shape[-1] == n**2
     square_matrix = jnp.reshape(
         flattened_square_matrix, flattened_square_matrix.shape[:-1] + (n, n)
     )

--- a/tests/units/models/test_core.py
+++ b/tests/units/models/test_core.py
@@ -45,7 +45,7 @@ def test_resnet_in_regular_and_log_domain_match():
 
     # Define activation function with simple analog in log domain
     def activation_fn(x: Array) -> Array:
-        return jnp.sign(x) * (x ** 2) / 10
+        return jnp.sign(x) * (x**2) / 10
 
     # Define log domain version of the same activation function
     def log_domain_activation_fn(x: SLArray) -> SLArray:

--- a/tests/units/physics/test_spin.py
+++ b/tests/units/physics/test_spin.py
@@ -53,14 +53,14 @@ def test_sz_zero_singlet_spin_overlap():
     """
     # if spatial wavefunction is totally symmetric, then spin component is
     # antisymmetrized, so must be a singlet
-    local_spin_hop = physics.spin.create_local_spin_hop(
+    local_spin_exchange = physics.spin.create_local_spin_exchange(
         slog_psi_apply=_symmetric_spatial_wavefn, nelec=jnp.array([1, 1])
     )
 
     nsamples, random_x = _get_random_samples(seed=2, nelec_total=2)
-    local_spin_hop_out = local_spin_hop(None, random_x)
+    local_spin_exchange_out = local_spin_exchange(None, random_x)
 
-    np.testing.assert_allclose(local_spin_hop_out, jnp.ones((nsamples,)))
+    np.testing.assert_allclose(local_spin_exchange_out, jnp.ones((nsamples,)))
 
 
 def test_sz_zero_triplet_spin_overlap():
@@ -73,28 +73,28 @@ def test_sz_zero_triplet_spin_overlap():
     for a two-particle <S_z> = 0 spin triplet state, which should give -1.
     """
     # if spatial wavefunction is antisymmetric, then spin component must be triplet
-    local_spin_hop = physics.spin.create_local_spin_hop(
+    local_spin_exchange = physics.spin.create_local_spin_exchange(
         slog_psi_apply=_two_particle_antisymmetric_spatial_wavefn,
         nelec=jnp.array([1, 1]),
     )
 
     nsamples, random_x = _get_random_samples(seed=53, nelec_total=2)
-    local_spin_hop_out = local_spin_hop(None, random_x)
+    local_spin_exchange_out = local_spin_exchange(None, random_x)
 
-    np.testing.assert_allclose(local_spin_hop_out, -jnp.ones((nsamples,)))
+    np.testing.assert_allclose(local_spin_exchange_out, -jnp.ones((nsamples,)))
 
 
 def test_sz_one_triplet_spin_overlap():
-    """Checks for zero spin hop overlap when only one spin species is present."""
-    local_spin_hop = physics.spin.create_local_spin_hop(
+    """Checks for zero spin exchange overlap when only one spin species is present."""
+    local_spin_exchange = physics.spin.create_local_spin_exchange(
         slog_psi_apply=_two_particle_antisymmetric_spatial_wavefn,
         nelec=jnp.array([2, 0]),
     )
 
     nsamples, random_x = _get_random_samples(seed=41, nelec_total=2)
-    local_spin_hop_out = local_spin_hop(None, random_x)
+    local_spin_exchange_out = local_spin_exchange(None, random_x)
 
-    np.testing.assert_allclose(local_spin_hop_out, jnp.zeros((nsamples,)))
+    np.testing.assert_allclose(local_spin_exchange_out, jnp.zeros((nsamples,)))
 
 
 def test_sz_zero_total_spin_six():
@@ -105,11 +105,11 @@ def test_sz_zero_total_spin_six():
     which implies that the spatial component is completely antisymmetric.
     """
     nelec = jnp.array([2, 2])
-    local_spin_hop = physics.spin.create_local_spin_hop(
+    local_spin_exchange = physics.spin.create_local_spin_exchange(
         slog_psi_apply=_four_particle_antisymmetric_spatial_wavefn, nelec=nelec
     )
     spin_square_expectation = physics.spin.create_spin_square_expectation(
-        local_spin_hop, nelec
+        local_spin_exchange, nelec
     )
 
     _, random_x = _get_random_samples(seed=3, nelec_total=4)
@@ -126,11 +126,11 @@ def test_sz_one_total_spin_six():
     which implies that the spatial component is completely antisymmetric.
     """
     nelec = jnp.array([3, 1])
-    local_spin_hop = physics.spin.create_local_spin_hop(
+    local_spin_exchange = physics.spin.create_local_spin_exchange(
         slog_psi_apply=_four_particle_antisymmetric_spatial_wavefn, nelec=nelec
     )
     spin_square_expectation = physics.spin.create_spin_square_expectation(
-        local_spin_hop, nelec
+        local_spin_exchange, nelec
     )
 
     _, random_x = _get_random_samples(seed=3, nelec_total=4)
@@ -147,11 +147,11 @@ def test_sz_two_total_spin_six():
     antisymmetrized spatial part).
     """
     nelec = jnp.array([4, 0])
-    local_spin_hop = physics.spin.create_local_spin_hop(
+    local_spin_exchange = physics.spin.create_local_spin_exchange(
         slog_psi_apply=_four_particle_antisymmetric_spatial_wavefn, nelec=nelec
     )
     spin_square_expectation = physics.spin.create_spin_square_expectation(
-        local_spin_hop, nelec
+        local_spin_exchange, nelec
     )
 
     _, random_x = _get_random_samples(seed=5, nelec_total=4)

--- a/tests/units/physics/test_spin.py
+++ b/tests/units/physics/test_spin.py
@@ -22,6 +22,19 @@ def _two_particle_antisymmetric_spatial_wavefn(unused_params, x):
     return array_to_slog(wavefn_amp)
 
 
+def _four_particle_antisymmetric_spatial_wavefn(unused_params, x):
+    del unused_params
+    wavefn_amp = (
+        (x[..., 0, 0] - x[..., 1, 0])
+        * (x[..., 0, 0] - x[..., 2, 0])
+        * (x[..., 0, 0] - x[..., 3, 0])
+        * (x[..., 1, 0] - x[..., 2, 0])
+        * (x[..., 1, 0] - x[..., 3, 0])
+        * (x[..., 2, 0] - x[..., 3, 0])
+    )
+    return array_to_slog(wavefn_amp)
+
+
 def _get_random_samples(seed, nelec_total):
     key = jax.random.PRNGKey(seed)
     nsamples = 10
@@ -72,14 +85,7 @@ def test_sz_zero_triplet_spin_overlap():
 
 
 def test_sz_one_triplet_spin_overlap():
-    """Compute overlap corresponding to exchange of a spin-up and spin-down electron.
-
-    This test computes
-
-        -(1/(N_up N_down)) <psi | sum_{i != j} S_{i+} * S_{j-} | psi> / <psi | psi>
-
-    for a two-particle <S_z> = 1 spin triplet state, which should give 0.
-    """
+    """Checks for zero spin hop overlap when only one spin species is present."""
     local_spin_hop = physics.spin.create_local_spin_hop(
         slog_psi_apply=_two_particle_antisymmetric_spatial_wavefn,
         nelec=jnp.array([2, 0]),
@@ -88,7 +94,7 @@ def test_sz_one_triplet_spin_overlap():
     nsamples, random_x = _get_random_samples(seed=41, nelec_total=2)
     local_spin_hop_out = local_spin_hop(None, random_x)
 
-    np.testing.assert_allclose(local_spin_hop_out, -jnp.zeros((nsamples,)))
+    np.testing.assert_allclose(local_spin_hop_out, jnp.zeros((nsamples,)))
 
 
 def test_sz_zero_total_spin_six():
@@ -98,19 +104,6 @@ def test_sz_zero_total_spin_six():
     n_down = 2, then <S^2> = 6 occurs when the spin component is completely symmetric,
     which implies that the spatial component is completely antisymmetric.
     """
-
-    def _four_particle_antisymmetric_spatial_wavefn(unused_params, x):
-        del unused_params
-        wavefn_amp = (
-            (x[..., 0, 0] - x[..., 1, 0])
-            * (x[..., 0, 0] - x[..., 2, 0])
-            * (x[..., 0, 0] - x[..., 3, 0])
-            * (x[..., 1, 0] - x[..., 2, 0])
-            * (x[..., 1, 0] - x[..., 3, 0])
-            * (x[..., 2, 0] - x[..., 3, 0])
-        )
-        return array_to_slog(wavefn_amp)
-
     nelec = jnp.array([2, 2])
     local_spin_hop = physics.spin.create_local_spin_hop(
         slog_psi_apply=_four_particle_antisymmetric_spatial_wavefn, nelec=nelec
@@ -132,19 +125,6 @@ def test_sz_one_total_spin_six():
     n_down = 1, then <S^2> = 6 occurs when the spin component is completely symmetric,
     which implies that the spatial component is completely antisymmetric.
     """
-
-    def _four_particle_antisymmetric_spatial_wavefn(unused_params, x):
-        del unused_params
-        wavefn_amp = (
-            (x[..., 0, 0] - x[..., 1, 0])
-            * (x[..., 0, 0] - x[..., 2, 0])
-            * (x[..., 0, 0] - x[..., 3, 0])
-            * (x[..., 1, 0] - x[..., 2, 0])
-            * (x[..., 1, 0] - x[..., 3, 0])
-            * (x[..., 2, 0] - x[..., 3, 0])
-        )
-        return array_to_slog(wavefn_amp)
-
     nelec = jnp.array([3, 1])
     local_spin_hop = physics.spin.create_local_spin_hop(
         slog_psi_apply=_four_particle_antisymmetric_spatial_wavefn, nelec=nelec
@@ -166,20 +146,7 @@ def test_sz_two_total_spin_six():
     n_down = 0, then the state must be an <S^2> = 6 eigenstate (given a properly
     antisymmetrized spatial part).
     """
-
-    def _four_particle_antisymmetric_spatial_wavefn(unused_params, x):
-        del unused_params
-        wavefn_amp = (
-            (x[..., 0, 0] - x[..., 1, 0])
-            * (x[..., 0, 0] - x[..., 2, 0])
-            * (x[..., 0, 0] - x[..., 3, 0])
-            * (x[..., 1, 0] - x[..., 2, 0])
-            * (x[..., 1, 0] - x[..., 3, 0])
-            * (x[..., 2, 0] - x[..., 3, 0])
-        )
-        return array_to_slog(wavefn_amp)
-
-    nelec = jnp.array([3, 1])
+    nelec = jnp.array([4, 0])
     local_spin_hop = physics.spin.create_local_spin_hop(
         slog_psi_apply=_four_particle_antisymmetric_spatial_wavefn, nelec=nelec
     )

--- a/tests/units/physics/test_spin.py
+++ b/tests/units/physics/test_spin.py
@@ -23,7 +23,7 @@ def _gaussian_two_particle_wavefn(unused_params, x):
     norms = jnp.linalg.norm(x, axis=-1)
     log_abs_wavefn = -(jnp.square(norms[..., 0]) + 3 * jnp.square(norms[..., 1]))
     sign_wavefn = jnp.ones_like(x[..., 0, 0])
-    return log_abs_wavefn, sign_wavefn
+    return sign_wavefn, log_abs_wavefn
 
 
 def _two_particle_antisymmetric_spatial_wavefn(unused_params, x):
@@ -131,7 +131,8 @@ def test_sz_zero_gaussian_spin_overlap():
     norms = jnp.linalg.norm(random_x, axis=-1)
     np.testing.assert_allclose(
         local_spin_exchange_out,
-        jnp.exp(2 * jnp.square(norms[..., 1]) - jnp.square(norms[..., 0])),
+        jnp.exp(2 * (jnp.square(norms[..., 1]) - jnp.square(norms[..., 0]))),
+        rtol=1e-5,
     )
 
 

--- a/tests/units/physics/test_spin.py
+++ b/tests/units/physics/test_spin.py
@@ -57,9 +57,9 @@ def test_sz_zero_singlet_spin_overlap():
 
     Because this is a spin eigenstate, this test computes
 
-        -(1/(N_up N_down)) <psi | sum_{i != j} S_{i+} * S_{j-} | psi> / <psi | psi>
+        <psi | sum_{i != j} S_{i+} * S_{j-} | psi> / <psi | psi>
 
-    for a two-particle <S_z> = 0 spin singlet state, which should give 1.
+    for a two-particle <S_z> = 0 spin singlet state, which should give -1.
     """
     # if spatial wavefunction is totally symmetric, then spin component is
     # antisymmetrized, so must be a singlet
@@ -70,7 +70,7 @@ def test_sz_zero_singlet_spin_overlap():
     nsamples, random_x = _get_random_samples(seed=2, nelec_total=2)
     local_spin_exchange_out = local_spin_exchange(None, random_x)
 
-    np.testing.assert_allclose(local_spin_exchange_out, jnp.ones((nsamples,)))
+    np.testing.assert_allclose(local_spin_exchange_out, -jnp.ones((nsamples,)))
 
 
 def test_sz_zero_triplet_spin_overlap():
@@ -78,9 +78,9 @@ def test_sz_zero_triplet_spin_overlap():
 
     Because this is a spin eigenstate, this test computes
 
-        -(1/(N_up N_down)) <psi | sum_{i != j} S_{i+} * S_{j-} | psi> / <psi | psi>
+        <psi | sum_{i != j} S_{i+} * S_{j-} | psi> / <psi | psi>
 
-    for a two-particle <S_z> = 0 spin triplet state, which should give -1.
+    for a two-particle <S_z> = 0 spin triplet state, which should give 1.
     """
     # if spatial wavefunction is antisymmetric, then spin component must be triplet
     local_spin_exchange = physics.spin.create_local_spin_exchange(
@@ -91,7 +91,7 @@ def test_sz_zero_triplet_spin_overlap():
     nsamples, random_x = _get_random_samples(seed=53, nelec_total=2)
     local_spin_exchange_out = local_spin_exchange(None, random_x)
 
-    np.testing.assert_allclose(local_spin_exchange_out, -jnp.ones((nsamples,)))
+    np.testing.assert_allclose(local_spin_exchange_out, jnp.ones((nsamples,)))
 
 
 def test_sz_one_triplet_spin_overlap():
@@ -114,11 +114,11 @@ def test_sz_zero_gaussian_spin_overlap():
     r_0 and r_1 are the norms of the electron positions. Because this is not a spin
     eigenstate, the local spin exchange computation simply computes
 
-        F(R_{1 <-> 1 + nelec[0]}) / F(R),
+        - nelec[0] * nelec[1] * F(R_{1 <-> 1 + nelec[0]}) / F(R),
 
     which amounts to computing the function
 
-        exp(-(3 * r_0^2 + r_1^2) + (r_0^2 + 3 * r_1^2)) = exp(2 * (r_1^2 - r_0^2)).
+        - exp(-(3 * r_0^2 + r_1^2) + (r_0^2 + 3 * r_1^2)) = - exp(2 * (r_1^2 - r_0^2)).
     """
     local_spin_exchange = physics.spin.create_local_spin_exchange(
         slog_psi_apply=_gaussian_two_particle_wavefn,
@@ -131,7 +131,7 @@ def test_sz_zero_gaussian_spin_overlap():
     norms = jnp.linalg.norm(random_x, axis=-1)
     np.testing.assert_allclose(
         local_spin_exchange_out,
-        jnp.exp(2 * (jnp.square(norms[..., 1]) - jnp.square(norms[..., 0]))),
+        -jnp.exp(2 * (jnp.square(norms[..., 1]) - jnp.square(norms[..., 0]))),
         rtol=1e-5,
     )
 

--- a/tests/units/physics/test_spin.py
+++ b/tests/units/physics/test_spin.py
@@ -1,0 +1,193 @@
+"""Testing spin calcuations.
+
+The spatial parts of the wavefunctions tested here are required to be antisymmetric
+with respect to exchange of like-spin particles.
+"""
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import vmcnet.physics as physics
+from vmcnet.utils.slog_helpers import array_to_slog
+
+
+def _symmetric_spatial_wavefn(unused_params, x):
+    del unused_params
+    return jnp.ones_like(x[..., 0, 0]), jnp.zeros_like(x[..., 0, 0])
+
+
+def _two_particle_antisymmetric_spatial_wavefn(unused_params, x):
+    del unused_params
+    wavefn_amp = x[..., 0, 0] - x[..., 1, 0]
+    return array_to_slog(wavefn_amp)
+
+
+def _get_random_samples(seed, nelec_total):
+    key = jax.random.PRNGKey(seed)
+    nsamples = 10
+    random_x = jax.random.normal(key, (nsamples, nelec_total, 3))
+    return nsamples, random_x
+
+
+def test_sz_zero_singlet_spin_overlap():
+    """Compute overlap corresponding to exchange of a spin-up and spin-down electron.
+
+    This test computes
+
+        -(1/(N_up N_down)) <psi | sum_{i != j} S_{i+} * S_{j-} | psi> / <psi | psi>
+
+    for a two-particle <S_z> = 0 spin singlet state, which should give 1.
+    """
+    # if spatial wavefunction is totally symmetric, then spin component is
+    # antisymmetrized, so must be a singlet
+    local_spin_hop = physics.spin.create_local_spin_hop(
+        slog_psi_apply=_symmetric_spatial_wavefn, nelec=jnp.array([1, 1])
+    )
+
+    nsamples, random_x = _get_random_samples(seed=2, nelec_total=2)
+    local_spin_hop_out = local_spin_hop(None, random_x)
+
+    np.testing.assert_allclose(local_spin_hop_out, jnp.ones((nsamples,)))
+
+
+def test_sz_zero_triplet_spin_overlap():
+    """Compute overlap corresponding to exchange of a spin-up and spin-down electron.
+
+    This test computes
+
+        -(1/(N_up N_down)) <psi | sum_{i != j} S_{i+} * S_{j-} | psi> / <psi | psi>
+
+    for a two-particle <S_z> = 0 spin triplet state, which should give -1.
+    """
+    # if spatial wavefunction is antisymmetric, then spin component must be triplet
+    local_spin_hop = physics.spin.create_local_spin_hop(
+        slog_psi_apply=_two_particle_antisymmetric_spatial_wavefn,
+        nelec=jnp.array([1, 1]),
+    )
+
+    nsamples, random_x = _get_random_samples(seed=53, nelec_total=2)
+    local_spin_hop_out = local_spin_hop(None, random_x)
+
+    np.testing.assert_allclose(local_spin_hop_out, -jnp.ones((nsamples,)))
+
+
+def test_sz_one_triplet_spin_overlap():
+    """Compute overlap corresponding to exchange of a spin-up and spin-down electron.
+
+    This test computes
+
+        -(1/(N_up N_down)) <psi | sum_{i != j} S_{i+} * S_{j-} | psi> / <psi | psi>
+
+    for a two-particle <S_z> = 1 spin triplet state, which should give 0.
+    """
+    local_spin_hop = physics.spin.create_local_spin_hop(
+        slog_psi_apply=_two_particle_antisymmetric_spatial_wavefn,
+        nelec=jnp.array([2, 0]),
+    )
+
+    nsamples, random_x = _get_random_samples(seed=41, nelec_total=2)
+    local_spin_hop_out = local_spin_hop(None, random_x)
+
+    np.testing.assert_allclose(local_spin_hop_out, -jnp.zeros((nsamples,)))
+
+
+def test_sz_zero_total_spin_six():
+    """Compute <psi| S^2 | psi> = 6 with two up and two down elec.
+
+    Direct computation shows that for a state with four electrons with n_up = 2 and
+    n_down = 2, then <S^2> = 6 occurs when the spin component is completely symmetric,
+    which implies that the spatial component is completely antisymmetric.
+    """
+
+    def _four_particle_antisymmetric_spatial_wavefn(unused_params, x):
+        del unused_params
+        wavefn_amp = (
+            (x[..., 0, 0] - x[..., 1, 0])
+            * (x[..., 0, 0] - x[..., 2, 0])
+            * (x[..., 0, 0] - x[..., 3, 0])
+            * (x[..., 1, 0] - x[..., 2, 0])
+            * (x[..., 1, 0] - x[..., 3, 0])
+            * (x[..., 2, 0] - x[..., 3, 0])
+        )
+        return array_to_slog(wavefn_amp)
+
+    nelec = jnp.array([2, 2])
+    local_spin_hop = physics.spin.create_local_spin_hop(
+        slog_psi_apply=_four_particle_antisymmetric_spatial_wavefn, nelec=nelec
+    )
+    spin_square_expectation = physics.spin.create_spin_square_expectation(
+        local_spin_hop, nelec
+    )
+
+    _, random_x = _get_random_samples(seed=3, nelec_total=4)
+    S2_expect = spin_square_expectation(None, random_x)
+
+    np.testing.assert_allclose(S2_expect, 6)
+
+
+def test_sz_one_total_spin_six():
+    """Compute <psi| S^2 | psi> = 6 with three up and one down elec.
+
+    Direct computation shows that for a state with four electrons with n_up = 3 and
+    n_down = 1, then <S^2> = 6 occurs when the spin component is completely symmetric,
+    which implies that the spatial component is completely antisymmetric.
+    """
+
+    def _four_particle_antisymmetric_spatial_wavefn(unused_params, x):
+        del unused_params
+        wavefn_amp = (
+            (x[..., 0, 0] - x[..., 1, 0])
+            * (x[..., 0, 0] - x[..., 2, 0])
+            * (x[..., 0, 0] - x[..., 3, 0])
+            * (x[..., 1, 0] - x[..., 2, 0])
+            * (x[..., 1, 0] - x[..., 3, 0])
+            * (x[..., 2, 0] - x[..., 3, 0])
+        )
+        return array_to_slog(wavefn_amp)
+
+    nelec = jnp.array([3, 1])
+    local_spin_hop = physics.spin.create_local_spin_hop(
+        slog_psi_apply=_four_particle_antisymmetric_spatial_wavefn, nelec=nelec
+    )
+    spin_square_expectation = physics.spin.create_spin_square_expectation(
+        local_spin_hop, nelec
+    )
+
+    _, random_x = _get_random_samples(seed=3, nelec_total=4)
+    S2_expect = spin_square_expectation(None, random_x)
+
+    np.testing.assert_allclose(S2_expect, 6)
+
+
+def test_sz_two_total_spin_six():
+    """Compute <psi| S^2 | psi> = 6 with four up and zero down elec.
+
+    Direct computation shows that for a state with four electrons with n_up = 4 and
+    n_down = 0, then the state must be an <S^2> = 6 eigenstate (given a properly
+    antisymmetrized spatial part).
+    """
+
+    def _four_particle_antisymmetric_spatial_wavefn(unused_params, x):
+        del unused_params
+        wavefn_amp = (
+            (x[..., 0, 0] - x[..., 1, 0])
+            * (x[..., 0, 0] - x[..., 2, 0])
+            * (x[..., 0, 0] - x[..., 3, 0])
+            * (x[..., 1, 0] - x[..., 2, 0])
+            * (x[..., 1, 0] - x[..., 3, 0])
+            * (x[..., 2, 0] - x[..., 3, 0])
+        )
+        return array_to_slog(wavefn_amp)
+
+    nelec = jnp.array([3, 1])
+    local_spin_hop = physics.spin.create_local_spin_hop(
+        slog_psi_apply=_four_particle_antisymmetric_spatial_wavefn, nelec=nelec
+    )
+    spin_square_expectation = physics.spin.create_spin_square_expectation(
+        local_spin_hop, nelec
+    )
+
+    _, random_x = _get_random_samples(seed=5, nelec_total=4)
+    S2_expect = spin_square_expectation(None, random_x)
+
+    np.testing.assert_allclose(S2_expect, 6)

--- a/tests/units/utils/test_slog_helpers.py
+++ b/tests/units/utils/test_slog_helpers.py
@@ -63,7 +63,7 @@ def test_sl_array_list_sum():
 
     sum = helpers.slog_array_list_sum(slogs)
     expected_sum = helpers.array_to_slog(jnp.array([0.0, 16.0, -1.7]))
-    assert_pytree_allclose(sum, expected_sum)
+    assert_pytree_allclose(sum, expected_sum, rtol=1e-6)
 
 
 def test_slog_sum():

--- a/tests/units/utils/test_slog_helpers.py
+++ b/tests/units/utils/test_slog_helpers.py
@@ -9,7 +9,7 @@ from vmcnet.utils.typing import Array, SLArray
 
 
 def _get_array_and_slog_vals() -> Tuple[Array, SLArray]:
-    vals = jnp.array([jnp.e, -jnp.e ** 0.5, 0, 1])
+    vals = jnp.array([jnp.e, -jnp.e**0.5, 0, 1])
     signs = jnp.array([1, -1, 0, 1])
     logs = jnp.array([1, 0.5, -jnp.inf, 0])
     return (vals, (signs, logs))

--- a/vmcnet/models/construct.py
+++ b/vmcnet/models/construct.py
@@ -842,7 +842,7 @@ class FermiNet(Module):
             elif self.determinant_fn_mode == DeterminantFnMode.PAIRWISE_EVEN:
                 # TODO (ggoldsh): build support for PAIRWISE_EVEN for nspins != 2
                 self._symmetrized_det_fn = make_array_list_fn_sign_invariant(
-                    functools.partial(self.determinant_fn, self.ndeterminants ** 2)
+                    functools.partial(self.determinant_fn, self.ndeterminants**2)
                 )
             else:
                 raise self._get_bad_determinant_fn_mode_error()

--- a/vmcnet/models/sign_symmetry.py
+++ b/vmcnet/models/sign_symmetry.py
@@ -22,7 +22,7 @@ def _get_sign_array_1d(i: int, nsyms: int) -> Array:
     # The exponent below is simply a clever way to get the value of the i_spin-th bit
     # of each integer in the sym_int array, to give us signs which alternate every
     # 2**i_spin values.
-    sym_signs_1d = (-1) ** jnp.sign((2 ** i) & sym_ints)
+    sym_signs_1d = (-1) ** jnp.sign((2**i) & sym_ints)
 
     return sym_signs_1d
 
@@ -67,7 +67,7 @@ def _get_sign_orbit_single_array(
         associated signs as a single array, i.e. [1, 1, -1, -1, 1, 1, ...]. This is
         returned so that downstream functions don't have to recompute it.
     """
-    nsyms = 2 ** n_total
+    nsyms = 2**n_total
     sym_signs_1d = _get_sign_array_1d(i, nsyms)
     sym_signs_shaped = _reshape_sign_array_for_orbit(sym_signs_1d, x.shape, axis, nsyms)
     return sym_signs_shaped * jnp.expand_dims(x, axis), sym_signs_1d
@@ -100,7 +100,7 @@ def _get_sign_orbit_single_sl_array(
         associated signs as a single array, i.e. [1, 1, -1, -1, 1, 1, ...]. This is
         returned so that downstream functions don't have to recompute it.
     """
-    nsyms = 2 ** n_total
+    nsyms = 2**n_total
     sym_signs_1d = _get_sign_array_1d(i, nsyms)
     sym_signs_shaped = _reshape_sign_array_for_orbit(
         sym_signs_1d, x[0].shape, axis, nsyms

--- a/vmcnet/physics/__init__.py
+++ b/vmcnet/physics/__init__.py
@@ -2,3 +2,4 @@
 from . import core
 from . import kinetic
 from . import potential
+from . import spin

--- a/vmcnet/physics/spin.py
+++ b/vmcnet/physics/spin.py
@@ -1,0 +1,88 @@
+"""Spin calculations."""
+from typing import Callable
+
+import jax.numpy as jnp
+
+from vmcnet.utils.distribute import get_mean_over_first_axis_fn
+from vmcnet.utils.typing import Array, P, ModelApply, SLArray
+
+
+def create_local_spin_hop(
+    slog_psi_apply: Callable[[P, Array], SLArray], nelec: Array
+) -> ModelApply[P]:
+    """Create the local observable from exchange of a spin-up and spin-down electron.
+
+    We assume a wavefunction of spin-1/2 particles. If the wavefunction psi is given by
+
+        psi(X) = antisymmetrize(F(R) xi(s)),
+
+    where R is the real-space coordinates in X and s are the corresponding spins, and
+    xi(s) is the spin configuration function corresponding to the S_z eigenstate with
+    the first nelec[0] electrons being spin-up and the last nelec[1] electrons being
+    spin-down.
+
+    This factory creates a function which computes
+
+        F(R_{1 <-> 1 + nelec[0]}) / F(R),
+
+    where R_{1 <-> 1 + nelec[0]} denotes the exchange of the first spin-up and spin-down
+    electron. When integrated over the distribution p(R) = |F(R)|^2 / int_R |F(R)|^2,
+    this quantity gives the overlap integral
+
+        -(1/(N_up N_down)) <psi | sum_{i != j} S_{i+} * S_{j-} | psi> / <psi | psi>,
+
+    where S_i+ and S_j- are the total spin raising and lowering operators, respectively
+    and the * operator means a tensor contraction along the Pauli spin index, i.e.
+
+    Args:
+        log_psi_apply (Callable): a function which computes log|psi(x)| for single
+            inputs x. It is okay for it to produce batch outputs on batches of x as long
+            as it produces a single number for single x. Has the signature
+            (params, single_x_in) -> log|psi(single_x_in)|
+        nelec (Array): an array of size (2,) with nelec[0] being the number of spin-up
+            electrons and nelec[1] being the number of spin-down electrons.
+
+    Returns:
+        Callable: function which computes the local kinetic energy for continuous
+        problems (as opposed to discrete/lattice problems), i.e. -0.5 nabla^2 psi / psi.
+        Evaluates on batches due to the jax.vmap call, so it has signature
+        (params, x) -> kinetic energy array with shape (x.shape[0],)
+    """
+    if nelec[0] == 0 or nelec[1] == 0:
+        # if only one spin species, then no hopping term
+        def local_spin_hop(params: P, x: Array) -> Array:
+            return jnp.zeros_like(x[..., 0, 0])
+
+    else:
+
+        def local_spin_hop(params: P, x: Array) -> Array:
+            sign_psi, log_psi = slog_psi_apply(params, x)
+
+            swapped_indices = list(range(x.shape[-2]))
+            swapped_indices[0], swapped_indices[nelec[0]] = nelec[0], 0
+            x_hopped = jnp.take(x, jnp.array(swapped_indices), axis=-2)
+            sign_hopped_psi, log_hopped_psi = slog_psi_apply(params, x_hopped)
+
+            sign_out = sign_psi * sign_hopped_psi
+            log_out = log_hopped_psi - log_psi
+            return sign_out * jnp.exp(log_out)
+
+    return local_spin_hop
+
+
+def create_spin_square_expectation(
+    local_spin_hop: ModelApply[P], nelec: Array, nan_safe: bool = True
+) -> Callable[[P, Array], jnp.float32]:
+    """Create a function which estimates the observable <psi | S^2 | psi>."""
+    mean_fn = get_mean_over_first_axis_fn(nan_safe=nan_safe)
+
+    def spin_square_expectation(params: P, x: Array) -> jnp.float32:
+        local_spin_hop_out = local_spin_hop(params, x)
+        spin_square = (
+            0.25 * (nelec[0] - nelec[1]) ** 2
+            + 0.5 * (nelec[0] + nelec[1])
+            - nelec[0] * nelec[1] * mean_fn(local_spin_hop_out)
+        )
+        return spin_square
+
+    return spin_square_expectation

--- a/vmcnet/physics/spin.py
+++ b/vmcnet/physics/spin.py
@@ -61,7 +61,7 @@ def create_spin_square_expectation(
         spin_square = (
             0.25 * (nelec[0] - nelec[1]) ** 2
             + 0.5 * (nelec[0] + nelec[1])
-            - nelec[0] * nelec[1] * mean_fn(local_spin_exchange_out)
+            + mean_fn(local_spin_exchange_out)
         )
         return spin_square
 
@@ -84,13 +84,13 @@ def create_local_spin_exchange(
 
     This factory creates a function which computes
 
-        F(R_{1 <-> 1 + nelec[0]}) / F(R),
+        -1 * nelec[0] * nelec[1] * F(R_{1 <-> 1 + nelec[0]}) / F(R),
 
     where R_{1 <-> 1 + nelec[0]} denotes the exchange of the first spin-up and spin-down
     electron. When integrated over the distribution p(R) = |F(R)|^2 / int_R |F(R)|^2,
     this quantity gives the overlap integral
 
-        -(1/(N_up N_down)) <psi | sum_{i != j} S_{i+} * S_{j-} | psi> / <psi | psi>,
+        <psi | sum_{i != j} S_{i+} * S_{j-} | psi> / <psi | psi>,
 
     where S_i+ and S_j- are the total spin raising and lowering operators, respectively,
     i.e. S_{i+} = S_{i,x} + iS_{i,y} and S_{j-} = S_{j,x} - iS_{j,y}.
@@ -105,7 +105,7 @@ def create_local_spin_exchange(
 
     Returns:
         Callable: function which computes a local spin exchange term, i.e. the function
-        F(R_{1 <-> 1 + nelec[0]}) / F(R). Has signature
+        nelec[0] * nelec[1] * F(R_{1 <-> 1 + nelec[0]}) / F(R). Has signature
         (params, x) -> local exchange term array with shape (x.shape[0],)
     """
     if nelec[0] == 0 or nelec[1] == 0:
@@ -125,6 +125,6 @@ def create_local_spin_exchange(
 
             sign_out = sign_psi * sign_exchanged_psi
             log_out = log_exchanged_psi - log_psi
-            return sign_out * jnp.exp(log_out)
+            return -nelec[0] * nelec[1] * sign_out * jnp.exp(log_out)
 
     return local_spin_exchange

--- a/vmcnet/physics/spin.py
+++ b/vmcnet/physics/spin.py
@@ -7,7 +7,68 @@ from vmcnet.utils.distribute import get_mean_over_first_axis_fn
 from vmcnet.utils.typing import Array, P, ModelApply, SLArray
 
 
-def create_local_spin_hop(
+def create_spin_square_expectation(
+    local_spin_exchange: ModelApply[P], nelec: Array, nan_safe: bool = True
+) -> Callable[[P, Array], jnp.float32]:
+    """Create a function which estimates the observable <psi | S^2 | psi> / <psi | psi>.
+
+    We assume a wavefunction of spin-1/2 particles. If the wavefunction psi is given by
+
+        psi(X) = antisymmetrize(F(R) xi(s)),
+
+    where R is the real-space coordinates in X and s are the corresponding spins, and
+    xi(s) is the spin configuration function corresponding to the S_z eigenstate with
+    the first nelec[0] electrons being spin-up and the last nelec[1] electrons being
+    spin-down.
+
+    The S^2 operator can be written as (sum_i S_i)^2, which can be decomposed in terms
+    of the total S_z operator and the raising and lowering operators S_{i+} and S_{i-},
+    i.e. S_{i+} = S_{i,x} + iS_{i,y} and S_{j-} = S_{j,x} - iS_{j,y}.
+
+    We have
+
+        S^2 = S_z^2 - S_z + sum_i S_{i+} * S_{i-} + sum_{i != j} S_{i+} * S_{j-}.
+
+    Direct calculation with the first three terms shows that
+
+        <psi | S_z^2 - S_z + sum_i S_{i+} * S_{i-} | psi>
+            = 0.25 (N_up - N_down)^2 + 0.5 (N_up + N_down).
+
+    The remaining term is computed by integrating a local electron exchange term, as
+    detailed in `create_local_spin_exchange`.
+
+    Args:
+        local_spin_exchange (Callable): a function which computes the local spin
+            exchange term, F(R_{1 <-> 1 + nelec[0]}) / F(R). Must have the signature
+            (params, x) -> local exchange term array with shape (x.shape[0],).
+        nelec (Array): an array of size (2,) with nelec[0] being the number of spin-up
+            electrons and nelec[1] being the number of spin-down electrons.
+        nan_safe (bool, optional): flag which controls if jnp.nanmean is used instead of
+            jnp.mean. Can be set to False when debugging if trying to find the source of
+            unexpected nans. Defaults to True.
+
+    Returns:
+        Callable: a function which computes the S^2 expectation for a wavefunction (not
+        necessarily normalized) given the number of spin-up and spin-down electrons and
+        a collection of samples used to estimate the local spin exchange. Has the
+        signature
+        (params, x) -> <psi | S^2 | psi> / <psi | psi>
+    """
+    mean_fn = get_mean_over_first_axis_fn(nan_safe=nan_safe)
+
+    def spin_square_expectation(params: P, x: Array) -> jnp.float32:
+        local_spin_exchange_out = local_spin_exchange(params, x)
+        spin_square = (
+            0.25 * (nelec[0] - nelec[1]) ** 2
+            + 0.5 * (nelec[0] + nelec[1])
+            - nelec[0] * nelec[1] * mean_fn(local_spin_exchange_out)
+        )
+        return spin_square
+
+    return spin_square_expectation
+
+
+def create_local_spin_exchange(
     slog_psi_apply: Callable[[P, Array], SLArray], nelec: Array
 ) -> ModelApply[P]:
     """Create the local observable from exchange of a spin-up and spin-down electron.
@@ -31,8 +92,8 @@ def create_local_spin_hop(
 
         -(1/(N_up N_down)) <psi | sum_{i != j} S_{i+} * S_{j-} | psi> / <psi | psi>,
 
-    where S_i+ and S_j- are the total spin raising and lowering operators, respectively
-    and the * operator means a tensor contraction along the Pauli spin index, i.e.
+    where S_i+ and S_j- are the total spin raising and lowering operators, respectively,
+    i.e. S_{i+} = S_{i,x} + iS_{i,y} and S_{j-} = S_{j,x} - iS_{j,y}.
 
     Args:
         log_psi_apply (Callable): a function which computes log|psi(x)| for single
@@ -43,46 +104,27 @@ def create_local_spin_hop(
             electrons and nelec[1] being the number of spin-down electrons.
 
     Returns:
-        Callable: function which computes the local kinetic energy for continuous
-        problems (as opposed to discrete/lattice problems), i.e. -0.5 nabla^2 psi / psi.
-        Evaluates on batches due to the jax.vmap call, so it has signature
-        (params, x) -> kinetic energy array with shape (x.shape[0],)
+        Callable: function which computes a local spin exchange term, i.e. the function
+        F(R_{1 <-> 1 + nelec[0]}) / F(R). Has signature
+        (params, x) -> local exchange term array with shape (x.shape[0],)
     """
     if nelec[0] == 0 or nelec[1] == 0:
-        # if only one spin species, then no hopping term
-        def local_spin_hop(params: P, x: Array) -> Array:
+        # if only one spin species, then no exchange term
+        def local_spin_exchange(params: P, x: Array) -> Array:
             return jnp.zeros_like(x[..., 0, 0])
 
     else:
 
-        def local_spin_hop(params: P, x: Array) -> Array:
+        def local_spin_exchange(params: P, x: Array) -> Array:
             sign_psi, log_psi = slog_psi_apply(params, x)
 
             swapped_indices = list(range(x.shape[-2]))
             swapped_indices[0], swapped_indices[nelec[0]] = nelec[0], 0
-            x_hopped = jnp.take(x, jnp.array(swapped_indices), axis=-2)
-            sign_hopped_psi, log_hopped_psi = slog_psi_apply(params, x_hopped)
+            x_exchanged = jnp.take(x, jnp.array(swapped_indices), axis=-2)
+            sign_exchanged_psi, log_exchanged_psi = slog_psi_apply(params, x_exchanged)
 
-            sign_out = sign_psi * sign_hopped_psi
-            log_out = log_hopped_psi - log_psi
+            sign_out = sign_psi * sign_exchanged_psi
+            log_out = log_exchanged_psi - log_psi
             return sign_out * jnp.exp(log_out)
 
-    return local_spin_hop
-
-
-def create_spin_square_expectation(
-    local_spin_hop: ModelApply[P], nelec: Array, nan_safe: bool = True
-) -> Callable[[P, Array], jnp.float32]:
-    """Create a function which estimates the observable <psi | S^2 | psi>."""
-    mean_fn = get_mean_over_first_axis_fn(nan_safe=nan_safe)
-
-    def spin_square_expectation(params: P, x: Array) -> jnp.float32:
-        local_spin_hop_out = local_spin_hop(params, x)
-        spin_square = (
-            0.25 * (nelec[0] - nelec[1]) ** 2
-            + 0.5 * (nelec[0] + nelec[1])
-            - nelec[0] * nelec[1] * mean_fn(local_spin_hop_out)
-        )
-        return spin_square
-
-    return spin_square_expectation
+    return local_spin_exchange

--- a/vmcnet/updates/params.py
+++ b/vmcnet/updates/params.py
@@ -251,7 +251,7 @@ def constrain_norm(
 ) -> P:
     """Constrains the preconditioned norm of the update, adapted from KFAC."""
     sq_norm_grads = tree_inner_product(preconditioned_grads, grads)
-    sq_norm_scaled_grads = sq_norm_grads * learning_rate ** 2
+    sq_norm_scaled_grads = sq_norm_grads * learning_rate**2
 
     # Sync the norms here, see:
     # https://github.com/deepmind/deepmind-research/blob/30799687edb1abca4953aec507be87ebe63e432d/kfac_ferminet_alpha/optimizer.py#L585


### PR DESCRIPTION
This PR adds some functions which compute the S^2 expectation (and local spin hop terms necessary to compute the S^2 expectation). After this is merged, next up is to expose these functions to the CLI.