### PR TITLE
Spin square runner and double sum calc

### DIFF
--- a/tests/integrations/train/test_runners.py
+++ b/tests/integrations/train/test_runners.py
@@ -91,7 +91,7 @@ def _run_and_check_output_files(mocker, tmp_path, config):
 
     # Check that evaluation is being done and metrics are being saved
     assert (inner_logdir / "eval").exists()
-    assert (inner_logdir / "eval" / "statistics.json").exists()
+    assert (inner_logdir / "eval" / "energy_statistics.json").exists()
     eval_metric_files = [
         "accept_ratio.txt",
         "energy.txt",

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -287,6 +287,7 @@ def get_default_vmc_config() -> Dict:
         "record_amplitudes": False,
         "record_param_l1_norm": False,
         "record_spin_squared": False,
+        "spin_sum_all_exchanges": True,
         "clip_threshold": 5.0,
         "clip_center": "mean",  # mean or median
         "nan_safe": True,
@@ -352,6 +353,7 @@ def get_default_eval_config() -> Dict:
         "use_data_from_training": False,
         "record_local_energies": True,  # save local energies and compute statistics
         "record_local_spin_exchanges": False,
+        "spin_sum_all_exchanges": True,
         "nan_safe": False,
     }
     return eval_config

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -351,7 +351,7 @@ def get_default_eval_config() -> Dict:
         # used as the initial positions instead
         "use_data_from_training": False,
         "record_local_energies": True,  # save local energies and compute statistics
-        "record_local_spin_hops": False,
+        "record_local_spin_exchanges": False,
         "nan_safe": False,
     }
     return eval_config

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -286,6 +286,7 @@ def get_default_vmc_config() -> Dict:
         "nhistory_max": 200,
         "record_amplitudes": False,
         "record_param_l1_norm": False,
+        "record_spin_squared": False,
         "clip_threshold": 5.0,
         "clip_center": "mean",  # mean or median
         "nan_safe": True,
@@ -350,6 +351,7 @@ def get_default_eval_config() -> Dict:
         # used as the initial positions instead
         "use_data_from_training": False,
         "record_local_energies": True,  # save local energies and compute statistics
+        "record_local_spin_hops": False,
         "nan_safe": False,
     }
     return eval_config

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -497,12 +497,14 @@ def _compute_and_save_statistics(
     local_observables_file_path: str,
     output_dir: str,
     output_filename: str,
+    scale: float = 1.0,
     offset: float = 0,
 ) -> None:
     local_observables = np.loadtxt(local_observables_file_path)
-    eval_statistics = mcmc.statistics.get_stats_summary(local_observables)
+    eval_statistics = mcmc.statistics.get_stats_summary(
+        scale * local_observables + offset
+    )
     eval_statistics = jax.tree_map(lambda x: float(x), eval_statistics)
-    eval_statistics["average"] = eval_statistics["average"] + offset
     utils.io.save_dict_to_json(
         eval_statistics,
         output_dir,
@@ -651,6 +653,7 @@ def run_molecule() -> None:
             local_spin_hops_filepath,
             eval_logdir,
             "spin_squared_statistics",
+            scale=-nelec[0] * nelec[1],
             offset=spin_squared_offset,
         )
 

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -659,7 +659,6 @@ def run_molecule() -> None:
             local_spin_exchanges_filepath,
             eval_logdir,
             "spin_squared_statistics",
-            scale=-nelec[0] * nelec[1],
             offset=spin_squared_offset,
         )
 
@@ -671,9 +670,9 @@ def vmc_statistics() -> None:
         "to disc."
     )
     parser.add_argument(
-        "local_energies_file_path",
+        "local_observables_file_path",
         type=str,
-        help="File path to load local energies from",
+        help="File path to load local observables from",
     )
     parser.add_argument(
         "output_file_path",
@@ -681,9 +680,24 @@ def vmc_statistics() -> None:
         help="File path to which to write the output statistics. The '.json' suffix "
         "will be appended to the supplied path.",
     )
+    parser.add_argument(
+        "scale",
+        type=float,
+        help="Amount to scale the local observables by before computing the statistics",
+    )
+    parser.add_argument(
+        "offset",
+        type=float,
+        help="Amount to shift the local observables by before computing the statistics",
+    )
+
     args = parser.parse_args()
 
     output_dir, output_filename = os.path.split(os.path.abspath(args.output_file_path))
     _compute_and_save_statistics(
-        args.local_energies_file_path, output_dir, output_filename
+        args.local_energies_file_path,
+        output_dir,
+        output_filename,
+        scale=args.scale,
+        offset=args.offset,
     )

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -343,7 +343,7 @@ def _setup_vmc(
     spin_squared_expectation_fn = None
     if config.vmc.record_spin_squared:
         local_spin_exchange_fn = physics.spin.create_local_spin_exchange(
-            slog_psi_apply, nelec
+            slog_psi_apply, nelec, config.vmc.spin_sum_all_exchanges
         )
         spin_squared_expectation_fn = physics.spin.create_spin_square_expectation(
             local_spin_exchange_fn, nelec, config.vmc.nan_safe
@@ -598,7 +598,7 @@ def run_molecule() -> None:
     local_spin_exchange_fn = None
     if config.eval.record_local_spin_exchanges:
         local_spin_exchange_fn = physics.spin.create_local_spin_exchange(
-            slog_psi_apply, nelec
+            slog_psi_apply, nelec, config.eval.spin_sum_all_exchanges
         )
 
     eval_update_param_fn, eval_burning_step, eval_walker_fn = _setup_eval(

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -681,13 +681,15 @@ def vmc_statistics() -> None:
         "will be appended to the supplied path.",
     )
     parser.add_argument(
-        "scale",
+        "--scale",
         type=float,
+        default=1.0,
         help="Amount to scale the local observables by before computing the statistics",
     )
     parser.add_argument(
-        "offset",
+        "--offset",
         type=float,
+        default=0.0,
         help="Amount to shift the local observables by before computing the statistics",
     )
 
@@ -695,7 +697,7 @@ def vmc_statistics() -> None:
 
     output_dir, output_filename = os.path.split(os.path.abspath(args.output_file_path))
     _compute_and_save_statistics(
-        args.local_energies_file_path,
+        args.local_observables_file_path,
         output_dir,
         output_filename,
         scale=args.scale,

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -4,7 +4,7 @@ import datetime
 import functools
 import logging
 import os
-from typing import Optional, Tuple
+from typing import Callable, Optional, Tuple
 
 import flax
 import jax

--- a/vmcnet/updates/params.py
+++ b/vmcnet/updates/params.py
@@ -212,9 +212,12 @@ def create_kfac_update_param_fn(
         if record_param_l1_norm:
             metrics.update({"param_l1_norm": stats_to_save[4]})
         if spin_square_expectation_fn is not None:
-            metrics.update(
-                {"spin_square": traced_compute_spin_square(params, positions)}
-            )
+            spin_squared_expectation = traced_compute_spin_square(params, positions)
+            if optimizer.multi_device:
+                spin_squared_expectation = utils.distribute.get_first(
+                    spin_squared_expectation
+                )
+            metrics.update({"spin_square": spin_squared_expectation})
 
         return params, optimizer_state, metrics, key
 

--- a/vmcnet/updates/params.py
+++ b/vmcnet/updates/params.py
@@ -249,10 +249,10 @@ def create_eval_update_param_fn(
         record_local_energies (bool, optional): whether to save the local energies at
             each walker position at each evaluation step. Allows for evaluation of the
             statistics of the local energies. Defaults to True.
-        local_spin_exchange_fn (Callable, optional): a function that can be used to compute
-            the local spin hop terms (see vmcnet.physics.spin), which can be used to
-            compute the total spin squared expectation. Allows for evaluation of the
-            statistics of the local spin squared observable. Defaults to None.
+        local_spin_exchange_fn (Callable, optional): a function that can be used to 
+            compute the local spin hop terms (see vmcnet.physics.spin), which can be
+            used to compute the total spin squared expectation. Allows for evaluation of
+            the statistics of the local spin squared observable. Defaults to None.
         nan_safe (bool, optional): whether or not to mask local energy nans in the
             evaluation process. This option should not be used under normal
             circumstances, as the energy estimates are of unclear validity if nans are

--- a/vmcnet/updates/params.py
+++ b/vmcnet/updates/params.py
@@ -249,7 +249,7 @@ def create_eval_update_param_fn(
         record_local_energies (bool, optional): whether to save the local energies at
             each walker position at each evaluation step. Allows for evaluation of the
             statistics of the local energies. Defaults to True.
-        local_spin_exchange_fn (Callable, optional): a function that can be used to 
+        local_spin_exchange_fn (Callable, optional): a function that can be used to
             compute the local spin hop terms (see vmcnet.physics.spin), which can be
             used to compute the total spin squared expectation. Allows for evaluation of
             the statistics of the local spin squared observable. Defaults to None.

--- a/vmcnet/updates/params.py
+++ b/vmcnet/updates/params.py
@@ -295,7 +295,7 @@ def constrain_norm(
 ) -> P:
     """Constrains the preconditioned norm of the update, adapted from KFAC."""
     sq_norm_grads = tree_inner_product(preconditioned_grads, grads)
-    sq_norm_scaled_grads = sq_norm_grads * learning_rate ** 2
+    sq_norm_scaled_grads = sq_norm_grads * learning_rate**2
 
     # Sync the norms here, see:
     # https://github.com/deepmind/deepmind-research/blob/30799687edb1abca4953aec507be87ebe63e432d/kfac_ferminet_alpha/optimizer.py#L585


### PR DESCRIPTION
This PR adds the spin squared calculations to the molecular runner, and adds the option (as well as making it default) to compute the local exchange as a double sum over all exchanges of spin up and down electrons (instead of just the first spin up and down electrons), which satisfies a desirable zero-variance principle.