### PR TITLE
Limit chex version to make tests pass on Ubuntu

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ console_scripts =
 [options.extras_require]
 testing =
     black==22.1.0
-    chex>=0.0.7
+    chex>=0.0.7,<0.1.5
     pytest>=6.0
     pytest-mock>=3.6
     pytest-cov>=2.0


### PR DESCRIPTION
Pulling in a single line change from @JiahaoYao 's WIP PR #108 since this update to the chex version seems to be required for any tests to pass (and is currently causing my other PRs to fail).

Once this is merged I'll rebase my other PRs and then those tests should pass.