### PR TITLE
Fix (some) VMCNET nans

### DIFF
--- a/tests/integrations/examples/kfac_train.py
+++ b/tests/integrations/examples/kfac_train.py
@@ -11,6 +11,7 @@ import vmcnet.utils as utils
 from vmcnet.mcmc.position_amplitude_core import (
     distribute_position_amplitude_data,
     get_position_from_data,
+    get_update_data_fn,
 )
 from vmcnet.mcmc.simple_position_amplitude import (
     make_simple_pos_amp_gaussian_step,
@@ -69,7 +70,10 @@ def kfac_vmc_loop_with_logging(
     )
 
     update_param_fn = updates.params.create_kfac_update_param_fn(
-        optimizer, 0.001, get_position_from_data
+        optimizer,
+        0.001,
+        get_position_from_data,
+        get_update_data_fn(log_psi_model.apply),
     )
 
     # Distribute everything via jax.pmap

--- a/tests/integrations/examples/sgd_train.py
+++ b/tests/integrations/examples/sgd_train.py
@@ -11,6 +11,7 @@ import vmcnet.utils as utils
 from vmcnet.mcmc.position_amplitude_core import (
     distribute_position_amplitude_data,
     get_position_from_data,
+    get_update_data_fn,
 )
 from vmcnet.mcmc.simple_position_amplitude import (
     make_simple_pos_amp_gaussian_step,
@@ -59,6 +60,7 @@ def sgd_vmc_loop_with_logging(
         energy_data_val_and_grad,
         sgd_apply,
         get_position_from_data,
+        get_update_data_fn(log_psi_model.apply),
     )
 
     # Distribute everything via jax.pmap

--- a/tests/integrations/test_newton.py
+++ b/tests/integrations/test_newton.py
@@ -61,12 +61,11 @@ def test_vmc_loop_newtons_x_squared():
 
     # do Newton's method, x <- x - f'(x) / f''(x)
     def update_param_fn(x, data, optimizer_state, key):
-        del data
         dmodel = 2.0 * (x - a) + 4.0 * jnp.power(x - a, 3)
         ddmodel = 2.0 + 12.0 * jnp.power(x - a, 2)
 
         new_x = x - dmodel / ddmodel
-        return new_x, optimizer_state, None, key
+        return new_x, data, optimizer_state, None, key
 
     min_x, _, _, _ = train.vmc.vmc_loop(
         x,

--- a/tests/units/train/test_vmc.py
+++ b/tests/units/train/test_vmc.py
@@ -34,8 +34,7 @@ def test_vmc_loop_logging(caplog):
     }
 
     def update_param_fn(params, data, optimizer_state, key):
-        del data
-        return params, optimizer_state, fixed_metrics, key
+        return params, data, optimizer_state, fixed_metrics, key
 
     for pmapped in [True, False]:
         caplog.clear()
@@ -110,9 +109,8 @@ def test_vmc_loop_number_of_updates():
     )
 
     def update_param_fn(params, data, optimizer_state, key):
-        del data
         optimizer_state += 1
-        return params, optimizer_state, None, key
+        return params, data, optimizer_state, None, key
 
     data, key = mcmc.metropolis.burn_data(burning_step, nburn, params, data, key)
     _, new_optimizer_state, new_data, _ = train.vmc.vmc_loop(

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -334,6 +334,7 @@ def _setup_vmc(
         log_psi_apply, config.vmc, init_pos, params, apply_pmap=apply_pmap
     )
     get_amplitude_fn = pacore.get_amplitude_from_data
+    update_data_fn = pacore.get_update_data_fn(log_psi_apply)
 
     # Setup metropolis step
     burning_step, walker_fn = _get_mcmc_fns(
@@ -357,6 +358,7 @@ def _setup_vmc(
         params,
         data,
         pacore.get_position_from_data,
+        update_data_fn,
         energy_data_val_and_grad,
         key,
         apply_pmap=apply_pmap,

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -335,10 +335,6 @@ def _setup_vmc(
     )
     get_amplitude_fn = pacore.get_amplitude_from_data
     update_data_fn = pacore.get_update_data_fn(log_psi_apply)
-    if not apply_pmap:
-        update_data_fn = jax.jit(update_data_fn)
-    else:
-        update_data_fn = utils.distribute.pmap(update_data_fn)
 
     # Setup metropolis step
     burning_step, walker_fn = _get_mcmc_fns(

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -335,6 +335,10 @@ def _setup_vmc(
     )
     get_amplitude_fn = pacore.get_amplitude_from_data
     update_data_fn = pacore.get_update_data_fn(log_psi_apply)
+    if not apply_pmap:
+        update_data_fn = jax.jit(update_data_fn)
+    else:
+        update_data_fn = utils.distribute.pmap(update_data_fn)
 
     # Setup metropolis step
     burning_step, walker_fn = _get_mcmc_fns(

--- a/vmcnet/train/vmc.py
+++ b/vmcnet/train/vmc.py
@@ -113,7 +113,7 @@ def vmc_loop(
 
             accept_ratio, data, key = walker_fn(params, data, key)
 
-            params, optimizer_state, metrics, key = update_param_fn(
+            params, data, optimizer_state, metrics, key = update_param_fn(
                 params, data, optimizer_state, key
             )
 

--- a/vmcnet/updates/params.py
+++ b/vmcnet/updates/params.py
@@ -238,7 +238,7 @@ def create_eval_update_param_fn(
         metrics = {"energy": energy, "variance": variance}
         if record_local_energies:
             metrics.update({"local_energies": local_energies})
-        return params, optimizer_state, metrics, key
+        return params, data, optimizer_state, metrics, key
 
     traced_fn = _make_traced_fn_with_single_metrics(
         eval_update_param_fn, apply_pmap, {"energy", "variance"}

--- a/vmcnet/updates/parse_config.py
+++ b/vmcnet/updates/parse_config.py
@@ -17,6 +17,7 @@ from vmcnet.utils.typing import (
     OptimizerState,
     P,
     PRNGKey,
+    UpdateDataFn,
 )
 
 from .params import (
@@ -59,6 +60,7 @@ def get_update_fn_and_init_optimizer(
     params: P,
     data: D,
     get_position_fn: GetPositionFromData[D],
+    update_data_fn: UpdateDataFn[D, P],
     energy_data_val_and_grad: physics.core.ValueGradEnergyFn[P],
     key: PRNGKey,
     apply_pmap: bool = True,
@@ -103,6 +105,7 @@ def get_update_fn_and_init_optimizer(
             params,
             data,
             get_position_fn,
+            update_data_fn,
             energy_data_val_and_grad,
             key,
             learning_rate_schedule,
@@ -158,6 +161,7 @@ def get_kfac_update_fn_and_state(
     params: P,
     data: D,
     get_position_fn: GetPositionFromData[D],
+    update_data_fn: UpdateDataFn[D, P],
     energy_data_val_and_grad: physics.core.ValueGradEnergyFn[P],
     key: PRNGKey,
     learning_rate_schedule: Callable[[int], jnp.float32],
@@ -217,6 +221,7 @@ def get_kfac_update_fn_and_state(
         optimizer,
         optimizer_config.damping,
         pacore.get_position_from_data,
+        update_data_fn,
         record_param_l1_norm=record_param_l1_norm,
     )
 

--- a/vmcnet/updates/parse_config.py
+++ b/vmcnet/updates/parse_config.py
@@ -74,6 +74,7 @@ def get_update_fn_and_init_optimizer(
         params (pytree): params with which to initialize optimizer state
         data (pytree): data with which to initialize optimizer state
         get_position_fn (Callable): function which gets the position array from the data
+        update_data_fn (Callable): function which updates data for new params
         energy_data_val_and_grad (Callable): function which computes the clipped energy
             value and gradient. Has the signature
                 (params, x)
@@ -117,6 +118,7 @@ def get_update_fn_and_init_optimizer(
         (update_param_fn, optimizer_state,) = get_sgd_update_fn_and_state(
             params,
             get_position_fn,
+            update_data_fn,
             energy_data_val_and_grad,
             learning_rate_schedule,
             vmc_config.optimizer.sgd,
@@ -128,6 +130,7 @@ def get_update_fn_and_init_optimizer(
         (update_param_fn, optimizer_state,) = get_adam_update_fn_and_state(
             params,
             get_position_fn,
+            update_data_fn,
             energy_data_val_and_grad,
             learning_rate_schedule,
             vmc_config.optimizer.adam,
@@ -140,6 +143,7 @@ def get_update_fn_and_init_optimizer(
             log_psi_apply,
             params,
             get_position_fn,
+            update_data_fn,
             energy_data_val_and_grad,
             learning_rate_schedule,
             vmc_config.optimizer.sr,
@@ -175,6 +179,7 @@ def get_kfac_update_fn_and_state(
         params (pytree): params with which to initialize optimizer state
         data (pytree): data with which to initialize optimizer state
         get_position_fn (Callable): function which gets the position array from the data
+        update_data_fn (Callable): function which updates data for new params
         energy_data_val_and_grad (Callable): function which computes the clipped energy
             value and gradient. Has the signature
                 (params, x)
@@ -266,6 +271,7 @@ def _get_optax_update_fn_and_state(
     optimizer: optax.GradientTransformation,
     params: P,
     get_position_fn: GetPositionFromData[D],
+    update_data_fn: UpdateDataFn[D, P],
     energy_data_val_and_grad: physics.core.ValueGradEnergyFn[P],
     record_param_l1_norm: bool = False,
     apply_pmap: bool = True,
@@ -280,6 +286,7 @@ def _get_optax_update_fn_and_state(
         energy_data_val_and_grad,
         optimizer_apply,
         get_position_fn=get_position_fn,
+        update_data_fn=update_data_fn,
         record_param_l1_norm=record_param_l1_norm,
         apply_pmap=apply_pmap,
     )
@@ -292,6 +299,7 @@ def _get_optax_update_fn_and_state(
 def get_adam_update_fn_and_state(
     params: P,
     get_position_fn: GetPositionFromData[D],
+    update_data_fn: UpdateDataFn[D, P],
     energy_data_val_and_grad: physics.core.ValueGradEnergyFn[P],
     learning_rate_schedule: Callable[[int], jnp.float32],
     optimizer_config: ConfigDict,
@@ -303,6 +311,7 @@ def get_adam_update_fn_and_state(
     Args:
         params (pytree): params with which to initialize optimizer state
         get_position_fn (Callable): function which gets the position array from the data
+        update_data_fn (Callable): function which updates data for new params
         energy_data_val_and_grad (Callable): function which computes the clipped energy
             value and gradient. Has the signature
                 (params, x)
@@ -330,6 +339,7 @@ def get_adam_update_fn_and_state(
         optimizer,
         params,
         get_position_fn,
+        update_data_fn,
         energy_data_val_and_grad,
         record_param_l1_norm,
         apply_pmap,
@@ -339,6 +349,7 @@ def get_adam_update_fn_and_state(
 def get_sgd_update_fn_and_state(
     params: P,
     get_position_fn: GetPositionFromData[D],
+    update_data_fn: UpdateDataFn[D, P],
     energy_data_val_and_grad: physics.core.ValueGradEnergyFn[P],
     learning_rate_schedule: Callable[[int], jnp.float32],
     optimizer_config: ConfigDict,
@@ -350,6 +361,7 @@ def get_sgd_update_fn_and_state(
     Args:
         params (pytree): params with which to initialize optimizer state
         get_position_fn (Callable): function which gets the position array from the data
+        update_data_fn (Callable): function which updates data for new params
         energy_data_val_and_grad (Callable): function which computes the clipped energy
             value and gradient. Has the signature
                 (params, x)
@@ -377,6 +389,7 @@ def get_sgd_update_fn_and_state(
         optimizer,
         params,
         get_position_fn,
+        update_data_fn,
         energy_data_val_and_grad,
         record_param_l1_norm,
         apply_pmap,
@@ -387,6 +400,7 @@ def get_sr_update_fn_and_state(
     log_psi_apply: ModelApply[P],
     params: P,
     get_position_fn: GetPositionFromData[D],
+    update_data_fn: UpdateDataFn[D, P],
     energy_data_val_and_grad: physics.core.ValueGradEnergyFn[P],
     learning_rate_schedule: Callable[[int], jnp.float32],
     optimizer_config: ConfigDict,
@@ -402,6 +416,7 @@ def get_sr_update_fn_and_state(
             function is (params, x) -> log|psi(x)|
         params (pytree): params with which to initialize optimizer state
         get_position_fn (Callable): function which gets the position array from the data
+        update_data_fn (Callable): function which updates data for new params
         energy_data_val_and_grad (Callable): function which computes the clipped energy
             value and gradient. Has the signature
                 (params, x)
@@ -479,6 +494,7 @@ def get_sr_update_fn_and_state(
         energy_data_val_and_grad,
         optimizer_apply,
         get_position_fn=get_position_fn,
+        update_data_fn=update_data_fn,
         record_param_l1_norm=record_param_l1_norm,
         apply_pmap=apply_pmap,
     )

--- a/vmcnet/utils/typing.py
+++ b/vmcnet/utils/typing.py
@@ -73,5 +73,6 @@ ModelApply = Callable[[P, Array], Array]
 
 GetPositionFromData = Callable[[D], Array]
 GetAmplitudeFromData = GetPositionFromData[D]
+UpdateDataFn = Callable[[D, P], D]
 
 ClippingFn = Callable[[Array, jnp.float32], Array]


### PR DESCRIPTION
### Background
We for a long time been observing NaNs in VMCNET much more commonly than in the DeepMind FermiNet repository. For example when running the N2 molecule most runs would generate NaNs. I investigated this by checkpointing on NaNs and then reloading the checkpoint and checking the amplitude, parameters, etc.

The proximal cause of the NaNs I investigated was that a walker reached a very improbable location (amplitude i.e. 1e-70), which resulted in `grad(log(Psi))` becoming extremely large, causing the parameters to explode and resulting in NaNs in the following epoch.

The key the figuring out why this happened was turning on the flag to log the min and max amplitude at each epoch and noticing that the min amplitude was stuck at 1e-21 for many epochs before it suddenly jumped to 1e-70. When I say stuck I mean that the min amplitude was EXACTLY the same over and over for thousands of epochs. This is not a reasonable behavior since the parameters change every epoch, so even if the walker is not moving, we would expect the min amplitude to change at least somewhat epoch to epoch. 

This led me to realize that we were not updating the walker amplitudes when we updated the parameters. This meant a walker could get stuck if the optimization process caused the position it was in to become extremely unlikely, because the walker would retain its old amplitude which would make the acceptance probability of moving to a nearby location extremely small. Furthermore, if this extremely low probability event happened, then the amplitude would become extremely small and cause NaNs as I described above.

### Fix
Okay the explanation above is a bit complex, but the fix is quite simple: update the amplitudes when the parameters are updated! 

I tested the N2 molecule with this fix and got 4 runs in a row with no NaNs - much better than before!