### PR TITLE
Fix KFAC when running vmc-molecule with single ion

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ console_scripts =
 [options.extras_require]
 testing =
     black==23.1.0
-    chex>=0.1.5
+    chex>=0.1.5,<=0.1.6
     pytest>=6.0
     pytest-mock>=3.6
     pytest-cov>=2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ install_requires =
     absl-py>=0.12.0
     flax==0.6.7
     jax==0.4.6
-    jaxlib>=0.4.6
+    jaxlib==0.4.6
     kfac_jax @ git+https://github.com/deepmind/kfac-jax
     ml-collections>=0.1.1
     numpy>=1.22.0

--- a/vmcnet/models/core.py
+++ b/vmcnet/models/core.py
@@ -207,17 +207,31 @@ class Dense(Module):
 
 
 class ElementWiseMultiply(Module):
-    """Multiplies over the last 2 axes element-wise."""
+    """Multiplies over the last k axes element-wise.
 
+    Attributes:
+        k (int): the number of axes to involve in the operation. For example, if k=1,
+            the kernel will be of shape (inputs.shape[-1],), whereas if k=2, the kerenl
+            will be of shape (inputs.shape[-2], inputs.shape[1]).
+        kernel_init (WeightInitializer, optional): initializer function for the weight
+            matrix. Defaults to orthogonal initialization.
+    """
+
+    k: int
     kernel_init: WeightInitializer = get_kernel_initializer("orthogonal")
 
     @flax.linen.compact
     def __call__(self, inputs: Array) -> Array:  # type: ignore[override]
-        """DOes stuff"""
+        """Multiplies inputs element-wise by a kernel of parameters.
 
-        kernel = self.param(
-            "kernel", self.kernel_init, (inputs.shape[-2], inputs.shape[-1])
-        )
+        Args:
+            inputs (Array): Array of inputs.
+
+        Returns:
+            Array: the input array multiplied element-wise by the kernel.
+        """
+        kernel_shape = [inputs.shape[-self.k + i] for i in range(self.k)]
+        kernel = self.param("kernel", self.kernel_init, kernel_shape)
         return inputs * kernel
 
 

--- a/vmcnet/models/core.py
+++ b/vmcnet/models/core.py
@@ -207,17 +207,17 @@ class Dense(Module):
 
 
 class ElementWiseMultiply(Module):
-    """Multiplies over the last k axes element-wise.
+    """Multiplies over the last naxes axes element-wise.
 
     Attributes:
-        k (int): the number of axes to involve in the operation. For example, if k=1,
-            the kernel will be of shape (inputs.shape[-1],), whereas if k=2, the kerenl
-            will be of shape (inputs.shape[-2], inputs.shape[1]).
+        naxes (int): the number of axes to involve in the operation. For example,
+            if k=1, the kernel will be of shape (inputs.shape[-1],), whereas if k=2,
+            the kerenl will be of shape (inputs.shape[-2], inputs.shape[1]).
         kernel_init (WeightInitializer, optional): initializer function for the weight
             matrix. Defaults to orthogonal initialization.
     """
 
-    k: int
+    naxes: int
     kernel_init: WeightInitializer = get_kernel_initializer("orthogonal")
 
     @flax.linen.compact
@@ -230,7 +230,7 @@ class ElementWiseMultiply(Module):
         Returns:
             Array: the input array multiplied element-wise by the kernel.
         """
-        kernel_shape = [inputs.shape[-self.k + i] for i in range(self.k)]
+        kernel_shape = [inputs.shape[-self.naxes + i] for i in range(self.naxes)]
         kernel = self.param("kernel", self.kernel_init, kernel_shape)
         return inputs * kernel
 

--- a/vmcnet/models/core.py
+++ b/vmcnet/models/core.py
@@ -206,6 +206,21 @@ class Dense(Module):
         return y
 
 
+class ElementWiseMultiply(Module):
+    """Multiplies over the last 2 axes element-wise."""
+
+    kernel_init: WeightInitializer = get_kernel_initializer("orthogonal")
+
+    @flax.linen.compact
+    def __call__(self, inputs: Array) -> Array:  # type: ignore[override]
+        """DOes stuff"""
+
+        kernel = self.param(
+            "kernel", self.kernel_init, (inputs.shape[-2], inputs.shape[-1])
+        )
+        return inputs * kernel
+
+
 class LogDomainDense(Module):
     """A linear transformation applied on the last axis of the input, in the log domain.
 

--- a/vmcnet/models/equivariance.py
+++ b/vmcnet/models/equivariance.py
@@ -691,7 +691,9 @@ def _compute_exponential_envelopes_on_leaf(
     # Multiply elementwise over final two axes and sum over final axis, returning
     # (..., nelec, norbitals)
     return jnp.sum(
-        ElementWiseMultiply(k=2, kernel_init=kernel_initializer_ion)(inv_exp_distances),
+        ElementWiseMultiply(naxes=2, kernel_init=kernel_initializer_ion)(
+            inv_exp_distances
+        ),
         axis=-1,
     )
 

--- a/vmcnet/models/equivariance.py
+++ b/vmcnet/models/equivariance.py
@@ -12,6 +12,7 @@ from vmcnet.utils.typing import Array, ArrayList, InputStreams, ParticleSplit
 from .core import (
     Activation,
     Dense,
+    ElementWiseMultiply,
     Module,
     _split_mean,
     _valid_skip,
@@ -687,17 +688,11 @@ def _compute_exponential_envelopes_on_leaf(
     distances = jnp.linalg.norm(scale_out, axis=-1)
     inv_exp_distances = jnp.exp(-distances)  # (..., nelec, norbitals, nion)
 
-    # norbitals parallel maps return shape [norbitals: (..., nelec, 1, 1)]
-    lin_comb_nion = SplitDense(
-        norbitals,
-        (1,) * norbitals,
-        kernel_initializer=kernel_initializer_ion,
-        use_bias=False,
-    )(inv_exp_distances)
-    # Concatenate to shape (..., nelec, norbitals, 1)
-    lin_comb_nion_concat = jnp.concatenate(lin_comb_nion, axis=-2)
-
-    return jnp.squeeze(lin_comb_nion_concat, axis=-1)  # (..., nelec, norbitals)
+    # Multiply elementwise and sum over final axis, returning (..., nelec, nion)
+    return jnp.sum(
+        ElementWiseMultiply(kernel_init=kernel_initializer_ion)(inv_exp_distances),
+        axis=-1,
+    )
 
 
 def _compute_exponential_envelopes_all_splits(

--- a/vmcnet/models/equivariance.py
+++ b/vmcnet/models/equivariance.py
@@ -688,9 +688,10 @@ def _compute_exponential_envelopes_on_leaf(
     distances = jnp.linalg.norm(scale_out, axis=-1)
     inv_exp_distances = jnp.exp(-distances)  # (..., nelec, norbitals, nion)
 
-    # Multiply elementwise and sum over final axis, returning (..., nelec, nion)
+    # Multiply elementwise over final two axes and sum over final axis, returning
+    # (..., nelec, norbitals)
     return jnp.sum(
-        ElementWiseMultiply(kernel_init=kernel_initializer_ion)(inv_exp_distances),
+        ElementWiseMultiply(k=2, kernel_init=kernel_initializer_ion)(inv_exp_distances),
         axis=-1,
     )
 


### PR DESCRIPTION
I realized my previous PR #114 introduced a bug where KFAC would throw an error when running vmc-molecule on a system with only one ion.

On debugging it seems like kfac_jax has a bug where it ends up dividing by zero and throwing a floating point error when a layer of the network involves only 1x1 kernels, so that every block of the block-diagonal part of KFAC for that layer is simply a scalar.  This was exactly what was happening in our exponential envelope code.

I didn't see an immediate way to fix it through the KFAC tagging, partly because I don't deeply understand how the kfac_jax library works. However, that particular layer doesn't need to be written that way and it can just as easily be written as an element-wise multiplication followed by a sum over the final axis.  As such I fixed the bug by adding an ElementWiseMultiply Module and using this approach instead.

PTAL @nilin or @JiahaoYao 