### PR TITLE
Add ability to soften EI and EE potentials in VMCNet

### DIFF
--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -269,6 +269,8 @@ def get_default_molecular_config() -> Dict:
         "ion_pos": ((0.0, 0.0, -1.5069621), (0.0, 0.0, 1.5069621)),
         "ion_charges": (1.0, 3.0),
         "nelec": (2, 2),
+        "ei_softening": 0.0,
+        "ee_softening": 0.0,
     }
     return problem_config
 


### PR DESCRIPTION
The idea here is to add the ability to "soften" the `1/r` coulomb potential with its nasty singularity to something more smooth and with no singularity, to test the effect of the singularity on various VMC methods. 

Simple PR as our potential functions already had softening built in, we just never wired it up to be configurable in vmc-molecule. Now it can be configured i.e. with `vmc-molecule --config.problem.ei_softening=1.0`.

The tests on this PR will likely fail due for the same reasons the tests on #115 were initially failing, but once we merge that I'll rebase that on the new master and the tests here should pass too. 

PTAL @nilin  @JiahaoYao 
