### PR TITLE
Implement random particle optimization method

### DIFF
--- a/tests/integrations/examples/kfac_train.py
+++ b/tests/integrations/examples/kfac_train.py
@@ -59,6 +59,7 @@ def kfac_vmc_loop_with_logging(
         l2_reg=0.0,
         norm_constraint=0.001,
         value_func_has_aux=True,
+        value_func_has_rng=True,
         learning_rate_schedule=learning_rate_schedule,
         curvature_ema=0.95,
         inverse_update_period=1,

--- a/tests/integrations/examples/sgd_train.py
+++ b/tests/integrations/examples/sgd_train.py
@@ -35,7 +35,7 @@ def sgd_vmc_loop_with_logging(
     logdir=None,
     checkpoint_every=None,
     checkpoint_dir=None,
-    use_generic_gradient_estimator: bool = False,
+    local_energy_type: str = "standard",
 ):
     """Run a VMC test with a very simple SGD optimizer and given model."""
     # Setup metropolis step
@@ -58,7 +58,7 @@ def sgd_vmc_loop_with_logging(
         log_psi_model.apply,
         local_energy_fn,
         nchains,
-        use_generic_gradient_estimator=use_generic_gradient_estimator,
+        local_energy_type=local_energy_type,
     )
     update_param_fn = updates.params.create_grad_energy_update_param_fn(
         energy_data_val_and_grad,

--- a/tests/integrations/examples/test_hydrogen_like_atom.py
+++ b/tests/integrations/examples/test_hydrogen_like_atom.py
@@ -96,10 +96,10 @@ def test_hydrogen_like_sgd_vmc(caplog):
         jax.tree_util.tree_leaves(params)[0], nuclear_charge, rtol=1e-5
     )
 
-
+# TODO (ggoldsh): fix this test
 @pytest.mark.slow
 @pytest.mark.skip(
-    "kfac_jax seems to break on single-param models; throws division by zero error."
+    "kfac_jax seems to break on this single-param model; throws division by zero error."
 )
 def test_hydrogen_like_kfac_vmc(caplog):
     """Test exp(-a * r) converges (in 3-D) to a = nuclear charge with KFAC."""

--- a/tests/integrations/examples/test_hydrogen_like_atom.py
+++ b/tests/integrations/examples/test_hydrogen_like_atom.py
@@ -96,6 +96,7 @@ def test_hydrogen_like_sgd_vmc(caplog):
         jax.tree_util.tree_leaves(params)[0], nuclear_charge, rtol=1e-5
     )
 
+
 # TODO (ggoldsh): fix this test
 @pytest.mark.slow
 @pytest.mark.skip(

--- a/tests/units/examples/test_harmonic_oscillator.py
+++ b/tests/units/examples/test_harmonic_oscillator.py
@@ -45,8 +45,10 @@ def test_make_harmonic_oscillator_local_energy_with_zero_omega():
     multichain_x = jnp.reshape(jnp.arange(12, dtype=jnp.float32), (4, 3, 1))
 
     local_energy_fn = qho.make_harmonic_oscillator_local_energy(0.0, log_f)
-    vmapped_local_e = jax.vmap(local_energy_fn, in_axes=(None, 0), out_axes=0)
-    kinetic = vmapped_local_e(None, multichain_x)  # kinetic only because omega = 0
+    vmapped_local_e = jax.vmap(local_energy_fn, in_axes=(None, 0, None), out_axes=0)
+    kinetic = vmapped_local_e(
+        None, multichain_x, None
+    )  # kinetic only because omega = 0
 
     # expect -(1/2) (nabla^2 f) / f, so because d^2f/dx_i^2 = 2 for all i, for 3
     # particles per sample we expect each sample x to have kinetic energy
@@ -65,8 +67,8 @@ def test_make_harmonic_oscillator_local_energy_with_nonzero_omega():
     omega = 2.0
 
     local_energy_fn = qho.make_harmonic_oscillator_local_energy(omega, log_f)
-    vmapped_local_e = jax.vmap(local_energy_fn, in_axes=(None, 0), out_axes=0)
-    local_energy = vmapped_local_e(None, multichain_x)
+    vmapped_local_e = jax.vmap(local_energy_fn, in_axes=(None, 0, None), out_axes=0)
+    local_energy = vmapped_local_e(None, multichain_x, None)
 
     # expect -(1/2) (nabla^2 f) / f, so because d^2f/dx_i^2 = 2 for all i, for 3
     # particles per sample we expect each sample x to have kinetic energy

--- a/tests/units/physics/test_core.py
+++ b/tests/units/physics/test_core.py
@@ -36,7 +36,7 @@ def test_total_energy_grad():
     nchains = x.shape[0]
     key = jax.random.PRNGKey(0)
 
-    def local_energy_fn(a, x):
+    def local_energy_fn(a, x, key):
         return jnp.sum(x)
 
     # Based on the specific values returned by make_dummy_x

--- a/tests/units/physics/test_core.py
+++ b/tests/units/physics/test_core.py
@@ -34,6 +34,7 @@ def test_total_energy_grad():
     x = make_dummy_x()
     log_psi_grad_x = jnp.array([5.0, 25.0, 61.0])
     nchains = x.shape[0]
+    key = jax.random.PRNGKey(0)
 
     def local_energy_fn(a, x):
         return jnp.sum(x)
@@ -52,7 +53,7 @@ def test_total_energy_grad():
         log_psi_apply, local_energy_fn, nchains
     )
 
-    energy_data, grad_energy = total_energy_value_and_grad(a, x)
+    energy_data, grad_energy = total_energy_value_and_grad(a, key, x)
     energy = energy_data[0]
     variance = energy_data[1][0]
     local_energies = energy_data[1][1]

--- a/vmcnet/examples/hydrogen_like_atom.py
+++ b/vmcnet/examples/hydrogen_like_atom.py
@@ -3,6 +3,7 @@ from typing import Callable
 
 import chex
 import flax
+import jax
 import jax.numpy as jnp
 
 import vmcnet.models as models

--- a/vmcnet/examples/hydrogen_like_atom.py
+++ b/vmcnet/examples/hydrogen_like_atom.py
@@ -3,7 +3,6 @@ from typing import Callable
 
 import chex
 import flax
-import jax
 import jax.numpy as jnp
 
 import vmcnet.models as models

--- a/vmcnet/examples/hydrogen_like_atom.py
+++ b/vmcnet/examples/hydrogen_like_atom.py
@@ -7,7 +7,7 @@ import jax.numpy as jnp
 
 import vmcnet.models as models
 import vmcnet.physics as physics
-from vmcnet.utils.typing import Array, P, ModelApply
+from vmcnet.utils.typing import Array, P, LocalEnergyApply
 
 
 class HydrogenLikeWavefunction(models.core.Module):
@@ -53,7 +53,7 @@ def make_hydrogen_like_local_energy(
     log_psi_apply: Callable[[P, Array], Array],
     charge: chex.Scalar,
     d: int = 3,
-) -> ModelApply[P]:
+) -> LocalEnergyApply[P]:
     """Local energy calculation for the hydrogen-like atom in general dimension d.
 
     Args:

--- a/vmcnet/physics/__init__.py
+++ b/vmcnet/physics/__init__.py
@@ -2,5 +2,6 @@
 from . import core
 from . import kinetic
 from . import ibp
+from . import random_particle
 from . import potential
 from . import spin

--- a/vmcnet/physics/core.py
+++ b/vmcnet/physics/core.py
@@ -91,6 +91,7 @@ def laplacian_psi_over_psi(
     params: P,
     x: Array,
     nparticles: Optional[int] = None,
+    particle_perm: Optional[Array] = None,
 ) -> Array:
     """Compute (nabla^2 psi) / psi at x given a function which evaluates psi'(x)/psi.
 
@@ -124,7 +125,10 @@ def laplacian_psi_over_psi(
         params (pytree): model parameters, passed as the first arg of grad_log_psi
         x (Array): second input to grad_log_psi
         nparticles (int, Optional): when specified, only the first nparticles particles
-            are used to calculate the Laplacian. Defaults to None.
+            of the particle_perm are used to calculate the laplacian. Defaults to None.
+        particle_perm (Array, Optional): permutation of the particle indices whose
+            ordering determines which particles' laplacians get evaluated, for use
+            in conjunction with the random particle method and the nparticles argument.
 
     Returns:
         Array: "local" laplacian calculation, i.e. (nabla^2 psi) / psi
@@ -139,19 +143,32 @@ def laplacian_psi_over_psi(
         grad_log_psi_out = grad_log_psi_apply(params, jnp.reshape(flat_x_in, x_shape))
         return jnp.reshape(grad_log_psi_out, (-1,))
 
+    length = n
+    multiplier = 1
+    vecs = identity_mat
+
+    if nparticles is not None and particle_perm is not None:
+        length = 3 * nparticles
+        multiplier = n / (3 * nparticles)
+
+        d = x_shape[-1]
+        triple_perm = jnp.stack([particle_perm * d + i for i in range(d)]).T.reshape(
+            (n,)
+        )
+        vecs = identity_mat[triple_perm, :]
+
     def step_fn(carry, unused):
         del unused
         i = carry[0]
         primals, tangents = jax.jvp(
-            flattened_grad_log_psi_of_flat_x, (flat_x,), (identity_mat[i],)
+            flattened_grad_log_psi_of_flat_x, (flat_x,), (vecs[i],)
         )
-        return (i + 1, carry[1] + jnp.square(primals[i]) + tangents[i]), None
-
-    length = n
-    multiplier = 1
-    if nparticles is not None:
-        length = 3 * nparticles
-        multiplier = n / (3 * nparticles)
+        return (
+            i + 1,
+            carry[1]
+            + jnp.square(jnp.dot(primals, vecs[i]))
+            + jnp.dot(tangents, vecs[i]),
+        ), None
 
     out, _ = jax.lax.scan(step_fn, (0, jnp.array(0.0)), xs=None, length=length)
     return out[1] * multiplier
@@ -232,8 +249,7 @@ def create_value_and_grad_energy_fn(
     nchains: int,
     clipping_fn: Optional[ClippingFn] = None,
     nan_safe: bool = True,
-    use_generic_gradient_estimator: bool = False,
-    shuffle_particles: bool = False,
+    local_energy_type: str = "standard",
 ) -> ValueGradEnergyFn[P]:
     """Create a function which computes unbiased energy gradients.
 
@@ -262,14 +278,18 @@ def create_value_and_grad_energy_fn(
             used instead of jnp.mean and jnp.sum for the terms in the gradient
             calculation. Can be set to False when debugging if trying to find the source
             of unexpected nans. Defaults to True.
-        use_generic_gradient_estimator (bool, optional): Flag to turn on the use of the
-            "generic" VMC gradient estimator which does not depend on the local energy
-            having the form APsi/Psi for a Hermitian operator A. In practice this means
-            an extra term must be added to the gradient in which the local energy itself
-            is differentiated with respect to the model parameters. This is useful for
-            example when using integration by parts to represent the kinetic energy
-            as the squared norm of the gradient of Psi rather than its Laplacian.
-            Defaults to False.
+        local_energy_type (str): one of [standard, ibp, random_particle]. "standard"
+            implies the standard VMC local energy in which case we can apply the
+            traditional VMC gradient estimator described above. "ibp" means integration
+            by parts in which case we use the "generic" VMC gradient estimator which
+            does not depend on the local energy having the form APsi/Psi for a Hermitian
+            operator A. In practice this means an extra term must be added to the
+            gradient in which the local energy itself is differentiated with respect to
+            the model parameters. "random_particle" means that the local energy uses one
+            or more random particles for each walker, rather than using all the
+            particles. In this case the standard gradient estimator can be used but the
+            code is slightly modified to pass a distinct PRNGkey to each walker.
+            Defaults to standard.
 
     Returns:
         Callable: function which computes the clipped energy value and gradient. Has the
@@ -282,7 +302,9 @@ def create_value_and_grad_energy_fn(
     mean_grad_fn = utils.distribute.get_mean_over_first_axis_fn(nan_safe=nan_safe)
 
     def standard_estimator_forward(
-        params: P, positions: Array, centered_local_energies: Array
+        params: P,
+        positions: Array,
+        centered_local_energies: Array,
     ) -> chex.Numeric:
         log_psi = log_psi_apply(params, positions)
         kfac_jax.register_normal_predictive_distribution(log_psi[:, None])
@@ -295,6 +317,42 @@ def create_value_and_grad_energy_fn(
             / (nchains - 1)
             * mean_grad_fn(centered_local_energies * log_psi)
         )
+
+    def get_standard_contribution(local_energies_noclip, params, positions):
+        energy, local_energies, aux_data = get_clipped_energies_and_aux_data(
+            local_energies_noclip, nchains, clipping_fn, nan_safe
+        )
+        centered_local_energies = local_energies - energy
+        grad_E = jax.grad(standard_estimator_forward, argnums=0)(
+            params, positions, centered_local_energies
+        )
+        return aux_data, energy, grad_E
+
+    def standard_energy_val_and_grad(params, key, positions):
+        del key
+
+        local_energies_noclip = jax.vmap(
+            local_energy_fn, in_axes=(None, 0), out_axes=0
+        )(params, positions)
+
+        aux_data, energy, grad_E = get_standard_contribution(
+            local_energies_noclip, params, positions
+        )
+
+        return (energy, aux_data), grad_E
+
+    def random_particle_energy_val_and_grad(params, key, positions):
+        nbatch = positions.shape[0]
+        key = jax.random.split(key, nbatch)
+
+        local_energies_noclip = jax.vmap(
+            local_energy_fn, in_axes=(None, 0, 0), out_axes=0
+        )(params, positions, key)
+
+        aux_data, energy, grad_E = get_standard_contribution(
+            local_energies_noclip, params, positions
+        )
+        return (energy, aux_data), grad_E
 
     def generic_energy_val_and_grad(params, key, positions):
         del key
@@ -325,29 +383,13 @@ def create_value_and_grad_energy_fn(
 
         return (energy, aux_data), grad_E
 
-    def standard_energy_val_and_grad(params, key, positions):
-        if shuffle_particles:
-            key = jax.random.split(key, positions.shape[0])
-            permute_fn = functools.partial(jax.random.permutation, axis=-2)
-            positions = jax.vmap(permute_fn)(key, positions)
-
-        local_energies_noclip = jax.vmap(
-            local_energy_fn, in_axes=(None, 0), out_axes=0
-        )(params, positions)
-
-        energy, local_energies, aux_data = get_clipped_energies_and_aux_data(
-            local_energies_noclip, nchains, clipping_fn, nan_safe
-        )
-
-        centered_local_energies = local_energies - energy
-
-        grad_E = jax.grad(standard_estimator_forward, argnums=0)(
-            params, positions, centered_local_energies
-        )
-
-        return (energy, aux_data), grad_E
-
-    if use_generic_gradient_estimator:
-        return generic_energy_val_and_grad
-    else:
+    if local_energy_type == "standard":
         return standard_energy_val_and_grad
+    elif local_energy_type == "ibp":
+        return generic_energy_val_and_grad
+    elif local_energy_type == "random_particle":
+        return random_particle_energy_val_and_grad
+    else:
+        raise ValueError(
+            f"Requested local energy type {local_energy_type} is not supported"
+        )

--- a/vmcnet/physics/ibp.py
+++ b/vmcnet/physics/ibp.py
@@ -136,7 +136,7 @@ def create_ibp_local_energy(
     ibp_ee: bool = True,
     ee_softening: chex.Scalar = 0.0,
 ):
-    """Create the full local energy for the integration by parts (IBP) method..
+    """Create the full local energy for the integration by parts (IBP) method.
 
     Args:
         log_psi_apply (Callable): a function which computes log|psi(x)| for single
@@ -161,7 +161,8 @@ def create_ibp_local_energy(
     Returns:
         Callable: function which computes the full local energy for the IBP method,
             with the requested terms integrated-by-parts and the other terms included
-            in their standard formulation.
+            in their standard formulation. Evaluates on only a single configuration
+            so must be externally vmapped to be applied to a batch of walkers.
     """
     ibp_energy = create_ibp_energy_term(
         log_psi_apply,

--- a/vmcnet/physics/ibp.py
+++ b/vmcnet/physics/ibp.py
@@ -5,7 +5,7 @@ import chex
 import jax
 import jax.numpy as jnp
 
-from vmcnet.utils.typing import Array, ArrayLike, P, ModelApply
+from vmcnet.utils.typing import Array, ArrayLike, LocalEnergyApply, ModelApply, P
 
 from .potential import (
     compute_displacements,
@@ -135,7 +135,7 @@ def create_ibp_local_energy(
     ei_softening: chex.Scalar = 0.0,
     ibp_ee: bool = True,
     ee_softening: chex.Scalar = 0.0,
-):
+) -> LocalEnergyApply[P]:
     """Create the full local energy for the integration by parts (IBP) method.
 
     Args:
@@ -192,6 +192,6 @@ def create_ibp_local_energy(
             create_electron_electron_coulomb_potential(softening_term=ee_softening)
         )
 
-    local_energy_fn: ModelApply[P] = combine_local_energy_terms(energy_terms)
+    local_energy_fn: LocalEnergyApply[P] = combine_local_energy_terms(energy_terms)
 
     return local_energy_fn

--- a/vmcnet/physics/kinetic.py
+++ b/vmcnet/physics/kinetic.py
@@ -9,7 +9,6 @@ from vmcnet.utils.typing import Array, P, ModelApply
 
 def create_laplacian_kinetic_energy(
     log_psi_apply: Callable[[P, Array], Array],
-    nparticles: Optional[int] = None,
 ) -> ModelApply[P]:
     """Create the local kinetic energy fn (params, x) -> -0.5 (nabla^2 psi(x) / psi(x)).
 
@@ -18,8 +17,6 @@ def create_laplacian_kinetic_energy(
             inputs x. It is okay for it to produce batch outputs on batches of x as long
             as it produces a single number for single x. Has the signature
             (params, single_x_in) -> log|psi(single_x_in)|
-        nparticles (int, Optional): when specified, only the first nparticles particles
-            are used to calculate the kinetic energy. Defaults to None.
 
     Returns:
         Callable: function which computes the local kinetic energy for continuous
@@ -30,8 +27,6 @@ def create_laplacian_kinetic_energy(
     grad_log_psi_apply = jax.grad(log_psi_apply, argnums=1)
 
     def kinetic_energy_fn(params: P, x: Array) -> Array:
-        return -0.5 * physics.core.laplacian_psi_over_psi(
-            grad_log_psi_apply, params, x, nparticles
-        )
+        return -0.5 * physics.core.laplacian_psi_over_psi(grad_log_psi_apply, params, x)
 
     return kinetic_energy_fn

--- a/vmcnet/physics/kinetic.py
+++ b/vmcnet/physics/kinetic.py
@@ -1,5 +1,5 @@
 """Kinetic energy terms."""
-from typing import Callable, Optional
+from typing import Callable
 
 import jax
 

--- a/vmcnet/physics/potential.py
+++ b/vmcnet/physics/potential.py
@@ -155,7 +155,7 @@ def create_electron_electron_coulomb_potential(
         -> array of potential energies of shape electron_positions.shape[:-2]
     """
 
-    def potential_fn(params: ModelParams, x: ArrayLike) -> Array:
+    def potential_fn(params: ModelParams, x: Array) -> Array:
         del params
         electron_electron_displacements = compute_displacements(x, x)
         electron_electron_distances = compute_soft_norm(

--- a/vmcnet/physics/random_particle.py
+++ b/vmcnet/physics/random_particle.py
@@ -1,0 +1,141 @@
+"""Energy terms related to the random particle approach."""
+from typing import Callable, Optional
+
+import chex
+import jax
+import jax.numpy as jnp
+
+from vmcnet.utils.typing import Array, ModelApply, P
+
+from .core import laplacian_psi_over_psi
+from .kinetic import create_laplacian_kinetic_energy
+from .potential import (
+    create_electron_electron_coulomb_potential,
+    create_electron_ion_coulomb_potential,
+    create_ion_ion_coulomb_potential,
+)
+
+
+def create_random_particle_kinetic_energy(
+    log_psi_apply: Callable[[P, Array], Array],
+    nparticles: Optional[int] = None,
+) -> ModelApply[P]:
+    """Create the local kinetic energy fn (params, x) -> -0.5 (nabla^2 psi(x) / psi(x)).
+
+    Args:
+        log_psi_apply (Callable): a function which computes log|psi(x)| for single
+            inputs x. It is okay for it to produce batch outputs on batches of x as long
+            as it produces a single number for single x. Has the signature
+            (params, single_x_in) -> log|psi(single_x_in)|
+        nparticles (int, Optional): when specified, only the first nparticles particles
+            of the particle_perm are used to calculate the kinetic energy.
+            Defaults to None.
+
+
+    Returns:
+        Callable: function which computes the local kinetic energy for continuous
+        problems (as opposed to discrete/lattice problems), i.e. -0.5 nabla^2 psi / psi.
+        Evaluates on only a single configuration so must be externally vmapped
+        to be applied to a batch of walkers.
+    """
+    grad_log_psi_apply = jax.grad(log_psi_apply, argnums=1)
+
+    def kinetic_energy_fn(params: P, x: Array, particle_perm: Array) -> Array:
+        return -0.5 * laplacian_psi_over_psi(
+            grad_log_psi_apply, params, x, nparticles, particle_perm
+        )
+
+    return kinetic_energy_fn
+
+
+def assemble_random_particle_local_energy(
+    kinetic_term, potential_terms, sample_kinetic
+):
+    def local_energy_fn(params, positions, key):
+        total_particles = positions.shape[-2]
+        perm = jax.random.permutation(key, jnp.arange(total_particles))
+        permuted_positions = positions[perm, :]
+
+        result = (
+            kinetic_term(params, positions, perm)
+            if sample_kinetic
+            else kinetic_term(params, positions)
+        )
+
+        for potential_term in potential_terms:
+            result += potential_term(params, permuted_positions)
+
+        return result
+
+    return local_energy_fn
+
+
+def create_random_particle_local_energy(
+    log_psi_apply: Callable[[P, Array], Array],
+    ion_locations: Array,
+    ion_charges: Array,
+    nparticles: int = 1,
+    sample_kinetic: bool = True,
+    sample_ei: bool = True,
+    ei_softening: chex.Scalar = 0.0,
+    sample_ee: bool = True,
+    ee_softening: chex.Scalar = 0.0,
+):
+    """Create the full local energy for the random particle method.
+
+    This method evaluates the local energy using a randomly selected subset of the
+    particles for each walker, to obtain a cheaper but more noisy estimate of the
+    local energy.
+
+    Args:
+        log_psi_apply (Callable): a function which computes log|psi(x)| for single
+           inputs x. It is okay for it to produce batch outputs on batches of x as long
+           as it produces a single number for single x. Has the signature
+           (params, single_x_in) -> log|psi(single_x_in)|
+        ion_locations (Array): an (n, d) array of ion positions, where n is the
+            number of ion positions and d is the dimension of the space they live in
+        ion_charges (Array): an (n,) array of ion charges, in units of one
+            elementary charge (the charge of one electron).
+        nparticles (int): the number of particles to select to estimate the local
+            energy. Defaults to 1.
+        sample_kinetic (bool): whether to sample the kinetic energy. Defaults to
+            True.
+        sample_ei (bool): whether to sample the electron-ion Coulomb interaction.
+            Defaults to True.
+        ei_softening (chex.Scalar): softening term to add to the electron-ion
+            interaction to smooth out the singularity. Defaults to 0.0.
+        sample_ee (bool): whether to sample the electron-electron Coulomb interaction.
+            Defaults to True.
+        ee_softening (chex.Scalar): softening term to add to the electron-electron
+            interaction to smooth out the singularity. Defaults to 0.0.
+
+    Returns:
+        Callable: function which computes the full local energy for the IBP method,
+            with the requested terms integrated-by-parts and the other terms included
+            in their standard formulation.
+    """
+
+    ii_potential_fn = create_ion_ion_coulomb_potential(ion_locations, ion_charges)
+
+    ei_potential_fn = create_electron_ion_coulomb_potential(
+        ion_locations,
+        ion_charges,
+        softening_term=ei_softening,
+        nparticles=nparticles if sample_ei else None,
+    )
+
+    ee_potential_fn = create_electron_electron_coulomb_potential(
+        softening_term=ee_softening, nparticles=nparticles if sample_ee else None
+    )
+
+    kinetic_energy = (
+        create_random_particle_kinetic_energy(log_psi_apply, nparticles)
+        if sample_kinetic
+        else create_laplacian_kinetic_energy(log_psi_apply)
+    )
+
+    return assemble_random_particle_local_energy(
+        kinetic_energy,
+        [ii_potential_fn, ei_potential_fn, ee_potential_fn],
+        sample_kinetic,
+    )

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -284,7 +284,7 @@ def get_default_vmc_config() -> Dict:
         "nsteps_per_param_update": 10,
         "nmoves_per_width_update": 100,
         "std_move": 0.25,
-        "local_energy_type": "standard",  # [standard, ibp]
+        "local_energy_type": "standard",  # [standard, ibp, random_particle]
         "local_energy": get_default_local_energy_config(),
         "checkpoint_every": 5000,
         "best_checkpoint_every": 100,
@@ -353,7 +353,7 @@ def get_default_eval_config() -> Dict:
         "nmoves_per_width_update": 100,
         "record_amplitudes": False,
         "std_move": 0.25,
-        "local_energy_type": "standard",  # [standard, ibp]
+        "local_energy_type": "standard",  # [standard, ibp, random_particle]
         "local_energy": get_default_local_energy_config(),
         # if use_data_from_training=True, nchains, nmoves_per_width_update, and
         # std_move are completely ignored, and the data output from training is
@@ -368,15 +368,16 @@ def get_default_eval_config() -> Dict:
 def get_default_local_energy_config() -> Dict:
     """Get a default local energy configuration."""
     local_energy_config = {
+        "standard": {},
         "ibp": {
             # TODO (ggoldsh): modify input format here to be like below
             "kinetic": True,
             "ei": True,
             "ee": True,
         },
-        "standard": {
+        "random_particle": {
             "sample_parts": (),  # '("kinetic","ei","ee")', or some subset.
-            "nsamples": 1,
+            "nparticles": 1,
         },
     }
     return local_energy_config

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -369,9 +369,14 @@ def get_default_local_energy_config() -> Dict:
     """Get a default local energy configuration."""
     local_energy_config = {
         "ibp": {
+            # TODO (ggoldsh): modify input format here to be like below
             "kinetic": True,
             "ei": True,
             "ee": True,
+        },
+        "standard": {
+            "sample_parts": (),  # '("kinetic","ei","ee")', or some subset.
+            "nsamples": 1,
         },
     }
     return local_energy_config

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -370,13 +370,12 @@ def get_default_local_energy_config() -> Dict:
     local_energy_config = {
         "standard": {},
         "ibp": {
-            # TODO (ggoldsh): modify input format here to be like below
-            "kinetic": True,
-            "ei": True,
-            "ee": True,
+            # '("kinetic","ei","ee")', or some subset.
+            "ibp_parts": ("kinetic", "ei", "ee")
         },
         "random_particle": {
-            "sample_parts": (),  # '("kinetic","ei","ee")', or some subset.
+            # '("kinetic","ei","ee")', or some subset.
+            "sample_parts": ("kinetic", "ei", "ee"),
             "nparticles": 1,
         },
     }

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -237,14 +237,15 @@ def _assemble_mol_local_energy_fn(
         )
         return local_energy_fn
     if local_energy_type == "ibp":
+        ibp_parts = (local_energy_config.ibp.ibp_parts,)
         local_energy_fn = physics.ibp.create_ibp_local_energy(
             log_psi_apply,
             ion_pos,
             ion_charges,
-            local_energy_config.ibp.kinetic,
-            local_energy_config.ibp.ei,
+            "kinetic" in ibp_parts,
+            "ei" in ibp_parts,
             ei_softening,
-            local_energy_config.ibp.ee,
+            "ee" in ibp_parts,
             ee_softening,
         )
         return local_energy_fn

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -467,6 +467,7 @@ def _setup_eval(
         record_local_energies=eval_config.record_local_energies,
         nan_safe=eval_config.nan_safe,
         apply_pmap=apply_pmap,
+        use_PRNGKey=eval_config.local_energy_type == "random_particle",
     )
     eval_burning_step, eval_walker_fn = _get_mcmc_fns(
         eval_config, log_psi_apply, apply_pmap=apply_pmap

--- a/vmcnet/updates/params.py
+++ b/vmcnet/updates/params.py
@@ -17,7 +17,7 @@ from vmcnet.utils.typing import (
     Array,
     D,
     GetPositionFromData,
-    ModelApply,
+    LocalEnergyApply,
     OptimizerState,
     P,
     PRNGKey,
@@ -209,7 +209,7 @@ def create_kfac_update_param_fn(
 
 
 def create_eval_update_param_fn(
-    local_energy_fn: ModelApply[P],
+    local_energy_fn: LocalEnergyApply[P],
     nchains: int,
     get_position_fn: GetPositionFromData[D],
     apply_pmap: bool = True,

--- a/vmcnet/updates/params.py
+++ b/vmcnet/updates/params.py
@@ -104,7 +104,9 @@ def create_grad_energy_update_param_fn(
 
     def update_param_fn(params, data, optimizer_state, key):
         position = get_position_fn(data)
-        energy_data, grad_energy = energy_data_val_and_grad(params, position)
+        key, subkey = jax.random.split(key)
+
+        energy_data, grad_energy = energy_data_val_and_grad(params, subkey, position)
         energy, aux_energy_data = energy_data
 
         grad_energy = utils.distribute.pmean_if_pmap(grad_energy)

--- a/vmcnet/updates/parse_config.py
+++ b/vmcnet/updates/parse_config.py
@@ -219,7 +219,7 @@ def get_kfac_update_fn_and_state(
         l2_reg=optimizer_config.l2_reg,
         norm_constraint=optimizer_config.norm_constraint,
         value_func_has_aux=True,
-        value_func_has_rng=False,
+        value_func_has_rng=True,
         learning_rate_schedule=learning_rate_schedule,
         curvature_ema=optimizer_config.curvature_ema,
         inverse_update_period=optimizer_config.inverse_update_period,

--- a/vmcnet/utils/typing.py
+++ b/vmcnet/utils/typing.py
@@ -68,6 +68,7 @@ Backflow = Callable[[Array, Optional[Array]], Array]
 Jastrow = Callable[[Array, Array, Array, Array, Array], Array]
 
 ModelApply = Callable[[P, Array], Array]
+LocalEnergyApply = Callable[[P, Array, Optional[PRNGKey]], Array]
 
 GetPositionFromData = Callable[[D], Array]
 GetAmplitudeFromData = GetPositionFromData[D]


### PR DESCRIPTION
Implement random particle method which evaluates the local energy using 1 or more randomly chosen particles. Options to apply this to any combination of kinetic, EI potential, and EE potential term. 

Most of the relevant changes are in potential.py and random_particle.py.

Also I changed the interface of the IBP method a bit so that you can choose which parts to apply IBP to by only setting one "ibp_parts" paramater; the new random_particle option works the same way with "sample_parts".

Optimization now works qualitatively at least with standard, IBP, and random particle methods and with SGD, Adam, KFAC optimizer. After merging this PR next step is to do some more thorough tests on all of those variants on the Li atom, with regular and smooth potentials.

PTAL @nilin 