### PR TITLE
Add options for softening cusps in the FermiNet ansatz 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,9 +15,9 @@ packages =
 install_requires =
     absl-py>=0.12.0
     flax==0.6.7
-    jax==0.4.6
-    jaxlib==0.4.6
-    kfac_jax==0.0.3
+    jax==0.4.7
+    jaxlib==0.4.7
+    kfac_jax==0.0.5
     ml-collections>=0.1.1
     numpy>=1.22.0
     optax==0.1.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ install_requires =
     flax==0.6.7
     jax==0.4.6
     jaxlib==0.4.6
-    kfac_jax @ git+https://github.com/deepmind/kfac-jax
+    kfac_jax==0.0.3
     ml-collections>=0.1.1
     numpy>=1.22.0
     optax==0.1.4

--- a/tests/units/models/test_construct.py
+++ b/tests/units/models/test_construct.py
@@ -163,6 +163,7 @@ def _make_ferminets():
             models.weights.get_kernel_initializer("he_normal"),
             models.weights.get_kernel_initializer("lecun_normal"),
             models.weights.get_kernel_initializer("ones"),
+            0.0,
             models.weights.get_bias_initializer("uniform"),
             orbitals_use_bias=True,
             isotropic_decay=True,
@@ -208,6 +209,7 @@ def _make_embedded_particle_ferminets():
             models.weights.get_kernel_initializer("he_normal"),
             models.weights.get_kernel_initializer("lecun_normal"),
             models.weights.get_kernel_initializer("ones"),
+            0.0,
             models.weights.get_bias_initializer("uniform"),
             orbitals_use_bias=True,
             isotropic_decay=True,
@@ -271,6 +273,7 @@ def _make_extended_orbital_matrix_ferminets():
             kernel_initializer_envelope_ion=models.weights.get_kernel_initializer(
                 "ones"
             ),
+            envelope_softening=0.0,
             bias_initializer_orbital_linear=models.weights.get_bias_initializer(
                 "uniform"
             ),

--- a/vmcnet/models/construct.py
+++ b/vmcnet/models/construct.py
@@ -4,6 +4,7 @@ from enum import Enum
 import functools
 from typing import Callable, List, Optional, Sequence, Tuple, cast
 
+import chex
 import flax
 import jax
 import jax.numpy as jnp
@@ -159,6 +160,7 @@ def get_model_from_config(
                 kernel_initializer_envelope_ion=kernel_init_constructor(
                     model_config.kernel_init_envelope_ion
                 ),
+                envelope_softening=model_config.envelope_softening,
                 bias_initializer_orbital_linear=bias_init_constructor(
                     model_config.bias_init_orbital_linear
                 ),
@@ -201,6 +203,7 @@ def get_model_from_config(
                 kernel_initializer_envelope_ion=kernel_init_constructor(
                     model_config.kernel_init_envelope_ion
                 ),
+                envelope_softening=model_config.envelope_softening,
                 bias_initializer_orbital_linear=bias_init_constructor(
                     model_config.bias_init_orbital_linear
                 ),
@@ -244,6 +247,7 @@ def get_model_from_config(
                 kernel_initializer_envelope_ion=kernel_init_constructor(
                     model_config.kernel_init_envelope_ion
                 ),
+                envelope_softening=model_config.envelope_softening,
                 bias_initializer_orbital_linear=bias_init_constructor(
                     model_config.bias_init_orbital_linear
                 ),
@@ -766,6 +770,9 @@ class FermiNet(Module):
         kernel_initializer_envelope_ion (WeightInitializer): kernel initializer for the
             linear combination over the ions of exponential envelopes. Has signature
             (key, shape, dtype) -> Array
+        envelope_softening (float): amount by which to soften the cusp of the
+            exponential envelope. If set to c, then an ei distance of r is replaced by
+            sqrt(r^2 + c^2) - c.
         bias_initializer_orbital_linear (WeightInitializer): bias initializer for the
             linear part of the orbitals. Has signature
             (key, shape, dtype) -> Array
@@ -828,6 +835,7 @@ class FermiNet(Module):
     kernel_initializer_orbital_linear: WeightInitializer
     kernel_initializer_envelope_dim: WeightInitializer
     kernel_initializer_envelope_ion: WeightInitializer
+    envelope_softening: chex.Scalar
     bias_initializer_orbital_linear: WeightInitializer
     orbitals_use_bias: bool
     isotropic_decay: bool
@@ -951,6 +959,7 @@ class FermiNet(Module):
             kernel_initializer_envelope_dim=self.kernel_initializer_envelope_dim,
             kernel_initializer_envelope_ion=self.kernel_initializer_envelope_ion,
             bias_initializer_linear=self.bias_initializer_orbital_linear,
+            envelope_softening=self.envelope_softening,
             use_bias=self.orbitals_use_bias,
             isotropic_decay=self.isotropic_decay,
         )(stream_1e, r_ei)

--- a/vmcnet/models/equivariance.py
+++ b/vmcnet/models/equivariance.py
@@ -65,10 +65,12 @@ def compute_input_streams(
             the one-electron input. Defaults to True.
         ei_norm_softening (float, optional): constant used to soften the cusp of the ei
             norm. If set to c, then an ei norm of r is replaced by sqrt(r^2 + c^2) - c.
+            Defaults to 0.
         include_ee_norm (bool, optional): whether to include electron-electron distances
             in the two-electron input. Defaults to True.
         ee_norm_softening (float, optional): constant used to soften the cusp of the ee
             norm. If set to c, then an ee norm of r is replaced by sqrt(r^2 + c^2) - c.
+            Defaults to 0.
 
     Returns:
         (
@@ -122,6 +124,7 @@ def compute_electron_ion(
             the one-electron input. Defaults to True.
         ei_norm_softening (float, optional): constant used to soften the cusp of the ei
             norm. If set to c, then an ei norm of r is replaced by sqrt(r^2 + c^2) - c.
+            Defaults to 0.
 
     Returns:
         (Array, Optional[Array]):
@@ -163,6 +166,7 @@ def compute_electron_electron(
             in the two-electron input. Defaults to True.
         ee_norm_softening (float, optional): constant used to soften the cusp of the ee
             norm. If set to c, then an ee norm of r is replaced by sqrt(r^2 + c^2) - c.
+            Defaults to 0.
 
     Returns:
         (Array, Array):
@@ -782,7 +786,7 @@ class FermiNetOrbitalLayer(Module):
             part of the orbitals. Has signature (key, shape, dtype) -> Array
         envelope_softening (float): amount by which to soften the cusp of the
             exponential envelope. If set to c, then an ei distance of r is replaced by
-            sqrt(r^2 + c^2) - c. Defaults to 0.0
+            sqrt(r^2 + c^2) - c. Defaults to 0.
         use_bias (bool, optional): whether to add a bias term to the linear part of the
             orbitals. Defaults to True.
         isotropic_decay (bool, optional): whether the decay for each ion should be

--- a/vmcnet/models/equivariance.py
+++ b/vmcnet/models/equivariance.py
@@ -180,11 +180,10 @@ def compute_electron_electron(
     r_ee = compute_displacements(elec_pos, elec_pos)
     input_2e = r_ee
     if include_ee_norm:
-        r_ee_norm = compute_ee_norm_with_safe_diag(r_ee)
-        softened_ee_norm = (
-            jnp.sqrt(r_ee_norm**2 + ee_norm_softening**2) - ee_norm_softening
+        r_ee_norm = compute_ee_norm_with_safe_diag(
+            r_ee, softening_term=ee_norm_softening
         )
-        input_2e = jnp.concatenate([input_2e, softened_ee_norm], axis=-1)
+        input_2e = jnp.concatenate([input_2e, r_ee_norm], axis=-1)
     return input_2e, r_ee
 
 

--- a/vmcnet/models/equivariance.py
+++ b/vmcnet/models/equivariance.py
@@ -125,7 +125,9 @@ def compute_electron_ion(
         r_ei = compute_displacements(input_1e, ion_pos)
         input_1e = r_ei
         if include_ei_norm:
-            input_norm = jnp.linalg.norm(input_1e, axis=-1, keepdims=True)
+            input_norm = (
+                jnp.sqrt(jnp.linalg.norm(input_1e, axis=-1, keepdims=True) ** 2 + 1) - 1
+            )
             input_with_norm = jnp.concatenate([input_1e, input_norm], axis=-1)
             input_1e = jnp.reshape(input_with_norm, input_with_norm.shape[:-2] + (-1,))
     return input_1e, r_ei
@@ -153,7 +155,7 @@ def compute_electron_electron(
     r_ee = compute_displacements(elec_pos, elec_pos)
     input_2e = r_ee
     if include_ee_norm:
-        r_ee_norm = compute_ee_norm_with_safe_diag(r_ee)
+        r_ee_norm = jnp.sqrt(compute_ee_norm_with_safe_diag(r_ee) ** 2 + 1) - 1
         input_2e = jnp.concatenate([input_2e, r_ee_norm], axis=-1)
     return input_2e, r_ee
 
@@ -687,7 +689,7 @@ def _compute_exponential_envelopes_on_leaf(
     # scale_out has shape (..., nelec, norbitals, nion, d)
     distances = jnp.linalg.norm(scale_out, axis=-1)
     inv_exp_distances = jnp.exp(
-        -jnp.sqrt(distances**2 + 1)
+        -(jnp.sqrt(distances**2 + 1) - 1)
     )  # (..., nelec, norbitals, nion)
 
     # Multiply elementwise over final two axes and sum over final axis, returning

--- a/vmcnet/models/equivariance.py
+++ b/vmcnet/models/equivariance.py
@@ -686,7 +686,9 @@ def _compute_exponential_envelopes_on_leaf(
         )
     # scale_out has shape (..., nelec, norbitals, nion, d)
     distances = jnp.linalg.norm(scale_out, axis=-1)
-    inv_exp_distances = jnp.exp(-(distances**2))  # (..., nelec, norbitals, nion)
+    inv_exp_distances = jnp.exp(
+        -jnp.sqrt(distances**2 + 1)
+    )  # (..., nelec, norbitals, nion)
 
     # Multiply elementwise over final two axes and sum over final axis, returning
     # (..., nelec, norbitals)

--- a/vmcnet/models/equivariance.py
+++ b/vmcnet/models/equivariance.py
@@ -686,7 +686,7 @@ def _compute_exponential_envelopes_on_leaf(
         )
     # scale_out has shape (..., nelec, norbitals, nion, d)
     distances = jnp.linalg.norm(scale_out, axis=-1)
-    inv_exp_distances = jnp.exp(-distances)  # (..., nelec, norbitals, nion)
+    inv_exp_distances = jnp.exp(-(distances**2))  # (..., nelec, norbitals, nion)
 
     # Multiply elementwise over final two axes and sum over final axis, returning
     # (..., nelec, norbitals)

--- a/vmcnet/physics/core.py
+++ b/vmcnet/physics/core.py
@@ -17,10 +17,8 @@ from vmcnet.utils.typing import (
     ModelApply,
 )
 
-EnergyAuxData = Tuple[
-    chex.Numeric, Array, Optional[chex.Numeric], Optional[chex.Numeric]
-]
-EnergyData = Tuple[chex.Numeric, EnergyAuxData]
+EnergyAuxData = Tuple[Array, Array, Optional[Array], Optional[Array]]
+EnergyData = Tuple[Array, EnergyAuxData]
 ValueGradEnergyFn = Callable[[P, PRNGKey, Array], Tuple[EnergyData, P]]
 
 
@@ -183,7 +181,7 @@ def laplacian_psi_over_psi(
 
 def get_statistics_from_local_energy(
     local_energies: Array, nchains: int, nan_safe: bool = True
-) -> Tuple[chex.Numeric, chex.Numeric]:
+) -> Tuple[Array, Array]:
     """Collectively reduce local energies to an average energy and variance.
 
     Args:
@@ -218,7 +216,7 @@ def get_clipped_energies_and_aux_data(
     nchains: int,
     clipping_fn: Optional[ClippingFn],
     nan_safe: bool,
-) -> Tuple[chex.Numeric, Array, EnergyAuxData]:
+) -> Tuple[Array, Array, EnergyAuxData]:
     """Clip local energies if requested and return auxiliary data."""
     if clipping_fn is not None:
         # For the unclipped metrics, which are not used in the gradient, don't

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -272,8 +272,8 @@ def get_default_molecular_config() -> Dict:
         "ion_pos": ((0.0, 0.0, -1.5069621), (0.0, 0.0, 1.5069621)),
         "ion_charges": (1.0, 3.0),
         "nelec": (2, 2),
-        "ei_softening": 1.0,
-        "ee_softening": 1.0,
+        "ei_softening": 0.0,
+        "ee_softening": 0.0,
     }
     return problem_config
 

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -269,8 +269,8 @@ def get_default_molecular_config() -> Dict:
         "ion_pos": ((0.0, 0.0, -1.5069621), (0.0, 0.0, 1.5069621)),
         "ion_charges": (1.0, 3.0),
         "nelec": (2, 2),
-        "ei_softening": 0.0,
-        "ee_softening": 0.0,
+        "ei_softening": 1.0,
+        "ee_softening": 1.0,
     }
     return problem_config
 

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -111,7 +111,9 @@ def get_default_model_config() -> Dict:
     input_streams = {
         "include_2e_stream": True,
         "include_ei_norm": True,
+        "ei_norm_softening": 0.0,
         "include_ee_norm": True,
+        "ee_norm_softening": 0.0,
     }
 
     base_backflow_config = {
@@ -156,6 +158,7 @@ def get_default_model_config() -> Dict:
         "kernel_init_orbital_linear": {"type": "orthogonal", "scale": 2.0},
         "kernel_init_envelope_dim": {"type": "ones"},
         "kernel_init_envelope_ion": {"type": "ones"},
+        "envelope_softening": 0.0,
         "bias_init_orbital_linear": normal_init,
         "orbitals_use_bias": True,
         "isotropic_decay": True,

--- a/vmcnet/updates/parse_config.py
+++ b/vmcnet/updates/parse_config.py
@@ -1,7 +1,6 @@
 """Get update functions from ConfigDicts."""
-from typing import Callable, Optional, Tuple
+from typing import Tuple
 
-import chex
 from kfac_jax import Optimizer as kfac_Optimizer
 import optax
 from ml_collections import ConfigDict
@@ -15,6 +14,7 @@ import vmcnet.utils.curvature_tags_and_blocks as curvature_tags_and_blocks
 from vmcnet.utils.typing import (
     D,
     GetPositionFromData,
+    LearningRateSchedule,
     ModelApply,
     OptimizerState,
     P,
@@ -33,7 +33,7 @@ from .sr import SRMode, get_fisher_inverse_fn
 
 def _get_learning_rate_schedule(
     optimizer_config: ConfigDict,
-) -> Callable[[chex.Array], Optional[chex.Array]]:
+) -> LearningRateSchedule:
     if optimizer_config.schedule_type == "constant":
 
         def learning_rate_schedule(t):
@@ -179,7 +179,7 @@ def get_kfac_update_fn_and_state(
     update_data_fn: UpdateDataFn[D, P],
     energy_data_val_and_grad: physics.core.ValueGradEnergyFn[P],
     key: PRNGKey,
-    learning_rate_schedule: Callable[[chex.Array], Optional[chex.Array]],
+    learning_rate_schedule: LearningRateSchedule,
     optimizer_config: ConfigDict,
     record_param_l1_norm: bool = False,
     apply_pmap: bool = True,
@@ -251,7 +251,7 @@ def get_kfac_update_fn_and_state(
 
 
 def _get_adam_optax_optimizer(
-    learning_rate_schedule: Callable[[int], chex.Numeric],
+    learning_rate_schedule: LearningRateSchedule,
     optimizer_config: ConfigDict,
 ) -> optax.GradientTransformation:
     return optax.adam(
@@ -264,7 +264,7 @@ def _get_adam_optax_optimizer(
 
 
 def _get_sgd_optax_optimizer(
-    learning_rate_schedule: Callable[[int], chex.Numeric],
+    learning_rate_schedule: LearningRateSchedule,
     optimizer_config: ConfigDict,
 ) -> optax.GradientTransformation:
     return optax.sgd(
@@ -318,7 +318,7 @@ def get_adam_update_fn_and_state(
     get_position_fn: GetPositionFromData[D],
     update_data_fn: UpdateDataFn[D, P],
     energy_data_val_and_grad: physics.core.ValueGradEnergyFn[P],
-    learning_rate_schedule: Callable[[int], chex.Numeric],
+    learning_rate_schedule: LearningRateSchedule,
     optimizer_config: ConfigDict,
     record_param_l1_norm: bool = False,
     apply_pmap: bool = True,
@@ -368,7 +368,7 @@ def get_sgd_update_fn_and_state(
     get_position_fn: GetPositionFromData[D],
     update_data_fn: UpdateDataFn[D, P],
     energy_data_val_and_grad: physics.core.ValueGradEnergyFn[P],
-    learning_rate_schedule: Callable[[int], chex.Numeric],
+    learning_rate_schedule: LearningRateSchedule,
     optimizer_config: ConfigDict,
     record_param_l1_norm: bool = False,
     apply_pmap: bool = True,
@@ -419,7 +419,7 @@ def get_sr_update_fn_and_state(
     get_position_fn: GetPositionFromData[D],
     update_data_fn: UpdateDataFn[D, P],
     energy_data_val_and_grad: physics.core.ValueGradEnergyFn[P],
-    learning_rate_schedule: Callable[[int], chex.Numeric],
+    learning_rate_schedule: LearningRateSchedule,
     optimizer_config: ConfigDict,
     descent_config: ConfigDict,
     record_param_l1_norm: bool = False,

--- a/vmcnet/utils/distribute.py
+++ b/vmcnet/utils/distribute.py
@@ -2,7 +2,6 @@
 import functools
 from typing import Callable, Tuple
 
-import chex
 import jax
 import jax.numpy as jnp
 from jax import core
@@ -61,12 +60,12 @@ def get_first(obj: T) -> T:
 pmean_if_pmap = functools.partial(wrap_if_pmap(jax.lax.pmean), axis_name=PMAP_AXIS_NAME)
 
 
-def mean_all_local_devices(x: Array) -> chex.Numeric:
+def mean_all_local_devices(x: Array) -> Array:
     """Compute mean over all local devices if distributed, otherwise the usual mean."""
     return pmean_if_pmap(jnp.mean(x))
 
 
-def nanmean_all_local_devices(x: Array) -> chex.Numeric:
+def nanmean_all_local_devices(x: Array) -> Array:
     """Compute a nan-safe mean over all local devices."""
     return pmean_if_pmap(jnp.nanmean(x))
 

--- a/vmcnet/utils/typing.py
+++ b/vmcnet/utils/typing.py
@@ -41,6 +41,8 @@ S = TypeVar("S", bound=PyTree)
 # TODO: Figure out how to make kfac_opt.State not be interpreted by mypy as Any
 OptimizerState = Union[kfac_jax.optimizer.OptimizerState, optax.OptState]
 
+LearningRateSchedule = Callable[[Array], Array]
+
 ModelParams = Union[frozen_dict.FrozenDict, Dict[str, Any]]
 
 # VMC state needed for a checkpoint. Values are:


### PR DESCRIPTION
When using a soft potential it's also necessary to remove the cusps from the FermiNet ansatz to get accurate results. I've been doing this ad hoc but figured since it's come up a few times it'd be better to add the functionality to vmc-molecule.

Here I add options for setting a softening term in the input streams for the norm(Rei) and norm(Ree) terms, and also a softening term for the exponential envelopes to remove the cusps at the ion locations.

I also bump kfac-jax to 0.0.5 since this seems to work better in some cases, and fix some types to make the new version work. 