### PR TITLE
Fix gradient clipping

### DIFF
--- a/vmcnet/physics/core.py
+++ b/vmcnet/physics/core.py
@@ -228,7 +228,7 @@ def get_clipped_energies_and_aux_data(
 
         local_energies = clipping_fn(local_energies_noclip, energy_noclip)
         energy, variance = get_statistics_from_local_energy(
-            local_energies_noclip, nchains, nan_safe=nan_safe
+            local_energies, nchains, nan_safe=nan_safe
         )
 
         aux_data = (variance, local_energies_noclip, energy_noclip, variance_noclip)


### PR DESCRIPTION
It turns out the reason that we had to turn gradient clipping off to make H4 work was not because gradient clipping is bad, but because I broke the gradient clipping a month or so ago when I refactored the energy gradient code. 

Fix is simple - just need to use local_energies instead of local_energies_noclip in line 231 of physics/core.py. Now things work as expected again.

PTAL @tkayq  @nilin 