### PR TITLE
Refix KFAC registration by removing indexing into kernel

### DIFF
--- a/vmcnet/models/core.py
+++ b/vmcnet/models/core.py
@@ -239,7 +239,7 @@ class ElementWiseMultiply(Module):
         # Pad shape with extra dim since kernel initializers require at least 2D arrays.
         kernel_shape = [1, *kernel_shape]
         kernel = self.param("kernel", self.kernel_init, kernel_shape)
-        return inputs * kernel[0, ...]
+        return inputs * kernel
 
 
 class LogDomainDense(Module):


### PR DESCRIPTION
In previous PR #125 I attempted to fix the envelopes so that KFAC would register them properly, but just before merging I tweaked things in a way that rebroke it.

In order for KFAC to register as scale_and_shift it seems that the kernel must be multiplied directly onto the inputs without any indexing. This is actually fine for our application since jax broadcasting will handle the edge case where the kernel becomes larger than the inputs after padding. 

PTAL @nilin 