### PR TITLE
Upgrade versions of jax etc

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,13 +14,13 @@ packages =
     vmcnet
 install_requires =
     absl-py>=0.12.0
-    flax==0.6.7
-    jax>=0.4.12
-    jaxlib>=0.4.12
+    flax==0.7.2
+    jax==0.4.14
+    jaxlib==0.4.14
     kfac_jax==0.0.5
-    ml-collections>=0.1.1
-    numpy>=1.22.0
-    optax==0.1.4
+    ml-collections==0.1.1
+    numpy==1.22.4
+    optax==0.1.7
 python_requires = >=3.9
 zip_safe = no
 
@@ -32,7 +32,7 @@ console_scripts =
 [options.extras_require]
 testing =
     black==23.1.0
-    chex>=0.1.5,<=0.1.6
+    chex==0.1.7
     pytest>=6.0
     pytest-mock>=3.6
     pytest-cov>=2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     jaxlib==0.4.14
     kfac_jax==0.0.5
     ml-collections==0.1.1
-    numpy==1.22.4
+    numpy==1.25.2
     optax==0.1.7
 python_requires = >=3.9
 zip_safe = no
@@ -32,7 +32,7 @@ console_scripts =
 [options.extras_require]
 testing =
     black==23.1.0
-    chex==0.1.7
+    chex==0.1.8
     pytest>=6.0
     pytest-mock>=3.6
     pytest-cov>=2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ console_scripts =
 [options.extras_require]
 testing =
     black==23.1.0
-    chex==0.1.8
+    chex==0.1.82
     pytest>=6.0
     pytest-mock>=3.6
     pytest-cov>=2.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,6 @@
 """Shared pieces for the test suite."""
 from typing import Tuple
 
-import flax.core.frozen_dict as frozen_dict
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -67,9 +66,7 @@ def make_dummy_data_params_and_key():
     seed = 0
     key = jax.random.PRNGKey(seed)
     data = jnp.array([0, 0, 0, 0])
-    params = frozen_dict.freeze(
-        {"kernel_1": jnp.array([1, 2, 3]), "kernel_2": jnp.array([[4, 5], [6, 7]])}
-    )
+    params = {"kernel_1": jnp.array([1, 2, 3]), "kernel_2": jnp.array([[4, 5], [6, 7]])}
 
     return data, params, key
 
@@ -120,7 +117,7 @@ def get_dense_and_log_domain_dense_same_params(
     """Get matching params for Dense and LogDomainDense layers."""
     dense_params = dense_layer.init(key, batch)
     log_domain_params = _get_log_domain_params_for_dense_layer(dense_params["params"])
-    log_domain_params = frozen_dict.freeze({"params": log_domain_params})
+    log_domain_params = {"params": log_domain_params}
     return dense_params, log_domain_params
 
 
@@ -137,8 +134,8 @@ def get_resnet_and_log_domain_resnet_same_params(
         log_domain_layer_params = _get_log_domain_params_for_dense_layer(layer_params)
         log_domain_params[dense_layer_key] = log_domain_layer_params
 
-    frozen_params = frozen_dict.freeze({"params": log_domain_params})
-    return resnet_params, frozen_params
+    params = {"params": log_domain_params}
+    return resnet_params, params
 
 
 def assert_pytree_allclose(

--- a/vmcnet/physics/core.py
+++ b/vmcnet/physics/core.py
@@ -10,6 +10,7 @@ import vmcnet.utils as utils
 from vmcnet.utils.pytree_helpers import tree_sum
 from vmcnet.utils.typing import (
     Array,
+    ArrayLike,
     P,
     ClippingFn,
     PRNGKey,
@@ -310,7 +311,7 @@ def create_value_and_grad_energy_fn(
         params: P,
         positions: Array,
         centered_local_energies: Array,
-    ) -> chex.Numeric:
+    ) -> ArrayLike:
         log_psi = log_psi_apply(params, positions)
         kfac_jax.register_normal_predictive_distribution(log_psi[:, None])
         # NOTE: for the generic gradient estimator case it may be important to include

--- a/vmcnet/utils/io.py
+++ b/vmcnet/utils/io.py
@@ -3,7 +3,6 @@ import functools
 import os
 from typing import Any, Callable, Dict, IO, TypeVar
 
-import flax.core.frozen_dict as frozen_dict
 import jax
 import json
 from ml_collections import ConfigDict
@@ -103,7 +102,6 @@ def process_checkpoint_data_for_saving(
     only copy. Params must also be converted from a frozen_dict to a dict.
     """
     (epoch, data, params, optimizer_state, key) = checkpoint_data
-    params = params.unfreeze()
     if is_distributed:
         params = get_first(params)
         optimizer_state = get_first(optimizer_state)
@@ -151,8 +149,7 @@ def reload_vmc_state(directory: str, name: str) -> CheckpointData:
             if data.dtype == np.dtype("object"):
                 data = data.tolist()
 
-            # Params are stored by flax as a frozen dict, so mimic that behavior here.
-            params = frozen_dict.freeze(npz_data["p"].tolist())
+            params = npz_data["p"].tolist()
             optimizer_state = npz_data["o"].tolist()
             key = npz_data["k"]
             return (epoch, data, params, optimizer_state, key)


### PR DESCRIPTION
Goal is to get this to work with CPU, or Cuda 11, or Cuda 12, and to make the installation more plug and play. 

For cuda 11 you should be able to set up a new environment like:
```
pip install --upgrade "jax[cuda11_pip]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
pip install -e .[testing]
```

For cuda 12 
```
pip install --upgrade "jax[cuda12_pip]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
pip install -e .[testing]
```

