### PR TITLE
NA reload model state and datetime suffix

### DIFF
--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -79,6 +79,7 @@ def get_default_config() -> ConfigDict:
                 "distribute": True,
                 "debug_nans": False,  # If true, OVERRIDES config.distribute to be False
                 "initial_seed": 0,
+                "reload_model_state": "",
             }
         )
     )

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -618,10 +618,8 @@ def run_molecule() -> None:
         and reload_config.use_checkpoint_file
     )
 
-    breakpoint()
     if config.reload_model_state!="":
         params=utils.io.reload_model_state(config.reload_model_state)
-        breakpoint()
 
     elif reload_from_checkpoint:
         checkpoint_file_path = os.path.join(

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -620,6 +620,7 @@ def run_molecule() -> None:
 
     if config.reload_model_state!="":
         params=utils.io.reload_model_state(config.reload_model_state)
+        params=jax.tree_map(lambda x: x[None,...], params)
 
     elif reload_from_checkpoint:
         checkpoint_file_path = os.path.join(

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -618,7 +618,12 @@ def run_molecule() -> None:
         and reload_config.use_checkpoint_file
     )
 
-    if reload_from_checkpoint:
+    breakpoint()
+    if config.reload_model_state!="":
+        params=utils.io.reload_model_state(config.reload_model_state)
+        breakpoint()
+
+    elif reload_from_checkpoint:
         checkpoint_file_path = os.path.join(
             reload_config.logdir, reload_config.checkpoint_relative_file_path
         )

--- a/vmcnet/utils/io.py
+++ b/vmcnet/utils/io.py
@@ -155,6 +155,13 @@ def reload_vmc_state(directory: str, name: str) -> CheckpointData:
             return (epoch, data, params, optimizer_state, key)
 
 
+def reload_model_state(path: str):
+    with open(path,'rb') as file_handle:
+        with np.load(file_handle, allow_pickle=True) as npz_data:
+            breakpoint()
+            return npz_data["p"].tolist()
+
+
 def add_suffix_for_uniqueness(name, logdir, trailing_suffix=""):
     """Adds a numerical suffix to keep names unique in a directory.
 

--- a/vmcnet/utils/io.py
+++ b/vmcnet/utils/io.py
@@ -3,6 +3,7 @@ import functools
 import os
 from typing import Any, Callable, Dict, IO, TypeVar
 
+import flax
 import jax
 import json
 from ml_collections import ConfigDict
@@ -128,6 +129,7 @@ def save_vmc_state(directory, name, checkpoint_data: CheckpointData):
             e=epoch,
             d=data,
             p=params,
+            unfrozen_params=flax.core.unfreeze(params),
             o=optimizer_state,
             k=key,
         )
@@ -158,8 +160,8 @@ def reload_vmc_state(directory: str, name: str) -> CheckpointData:
 def reload_model_state(path: str):
     with open(path,'rb') as file_handle:
         with np.load(file_handle, allow_pickle=True) as npz_data:
-            breakpoint()
-            return npz_data["p"].tolist()
+            params=npz_data["unfrozen_params"].item()
+    return flax.core.freeze(params)
 
 
 def add_suffix_for_uniqueness(name, logdir, trailing_suffix=""):


### PR DESCRIPTION
Save params as unfrozen dict in checkpoint.npz

Reload params (i.e., model state):
--config.reload_model_state="full/path/to/checkpoint.npz" 

Add suffix to datetime to avoid multiple runs being mixed in energy.txt