### PR TITLE
fix DEFAULT_PRESETS_DIR

### DIFF
--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -10,7 +10,7 @@ NO_NAME = "NONE"
 NO_PATH = "NONE"
 NO_RELOAD_LOG_DIR = "NONE"
 DEFAULT_CONFIG_FILE_NAME = "config.json"
-DEFAULT_PRESETS_DIR = "./preset_configs"
+DEFAULT_PRESETS_DIR = "preset_configs"
 
 
 def _copy_all_dicts(config: Dict) -> Dict:

--- a/vmcnet/train/parse_config_flags.py
+++ b/vmcnet/train/parse_config_flags.py
@@ -33,7 +33,7 @@ def _get_config_from_default_config(
     base_config = train.default_config.get_default_config()
 
     if presets_path is not None:
-        presets = io.load_config_dict(".", presets_path)
+        presets = io.load_config_dict("", presets_path)
         base_config.update(presets)
 
     config_flags.DEFINE_config_dict(


### PR DESCRIPTION
Fix the error:
os.path.join( '.' , './path' ) -> '././path'
open( '././path' , 'rb' ) worked as open( 'path' , 'rb' ) on Mac but caused error on Debian