### PR TITLE
Continue previous run

### DIFF
--- a/preset_configs/H4.json
+++ b/preset_configs/H4.json
@@ -1,5 +1,6 @@
 {
     "notes": "H4, 4 Bohr",
+    "subfolder_name": "H4",
     "problem": {
         "ion_pos": [
             [ 0.0, 0.0, 0.0 ],
@@ -16,9 +17,5 @@
         "nelec": [
             2, 2
         ]
-    },
-    "vmc": {
-        "nepochs": 10000
-    },
-    "logdir": "logs/H4"
+    }
 }

--- a/preset_configs/quicktest.json
+++ b/preset_configs/quicktest.json
@@ -37,7 +37,7 @@
         "nburn": 100,
         "nsteps_per_param_update": 10,
         "nmoves_per_width_update": 100,
-        "moving_checkpoints_every": 100,
+        "best_checkpoint_every": 100,
         "optimizer_type": "sgd"
     },
     "eval": {

--- a/preset_configs/quicktest.json
+++ b/preset_configs/quicktest.json
@@ -1,5 +1,6 @@
 {
     "notes": "quicktest: He",
+    "subfolder_name": "quicktest",
     "problem": {
         "ion_pos": [
             [
@@ -44,6 +45,5 @@
         "nburn": 100,
         "nepochs": 100
     },
-    "logdir": "logs/quicktest",
     "save_to_current_datetime_subfolder": false
 }

--- a/preset_configs/quicktest.json
+++ b/preset_configs/quicktest.json
@@ -44,5 +44,6 @@
         "nburn": 100,
         "nepochs": 100
     },
-    "logdir": "logs/quicktest"
+    "logdir": "logs/quicktest",
+    "save_to_current_datetime_subfolder": false
 }

--- a/preset_configs/quicktest.json
+++ b/preset_configs/quicktest.json
@@ -36,7 +36,7 @@
         "nburn": 100,
         "nsteps_per_param_update": 10,
         "nmoves_per_width_update": 100,
-        "best_checkpoint_every": 100,
+        "moving_checkpoints_every": 100,
         "optimizer_type": "sgd"
     },
     "eval": {

--- a/tests/integrations/train/test_runners.py
+++ b/tests/integrations/train/test_runners.py
@@ -164,6 +164,7 @@ def test_reload_append(mocker, tmp_path):
         "--config.save_to_current_datetime_subfolder=False",
         "--config.logdir=" + path1,
         "--config.subfolder_name=NONE",
+        "--config.vmc.optimizer_type=kfac",
     ]
     mocker.patch("sys.argv", mock_argv1)
     train.runners.run_molecule()

--- a/tests/integrations/train/test_runners.py
+++ b/tests/integrations/train/test_runners.py
@@ -141,6 +141,13 @@ def test_run_molecule_jitted(mocker, tmp_path):
 
 @pytest.mark.very_slow
 def test_reload_append(mocker, tmp_path):
+    """Reload and continue a run from a checkpoint.
+
+    This runs an example for 10 epochs as run_1. It then reloads
+    from the checkpoint at 5 epochs and re-runs the last epochs
+    until 10 epochs total is reached again.
+    The energy histories from the two runs are compared.
+    """
     mocker.patch("os.curdir", tmp_path)
     path1 = (tmp_path / "run_1").as_posix()
     path2 = (tmp_path / "run_2").as_posix()

--- a/tests/integrations/train/test_runners.py
+++ b/tests/integrations/train/test_runners.py
@@ -209,4 +209,4 @@ def test_reload_append(mocker, tmp_path):
         assert(np.mean(np.diag(distmatrix))<eps*np.mean(distmatrix))
         print('test passed for',name)
 
-    np.assert_allclose(energies1, energies2, rtol=1e-6)
+    np.testing.assert_allclose(energies1, energies2, rtol=1e-6)

--- a/tests/integrations/train/test_runners.py
+++ b/tests/integrations/train/test_runners.py
@@ -164,7 +164,7 @@ def test_reload_append(mocker, tmp_path):
         "--config.vmc.checkpoint_every=1",
         "--config.save_to_current_datetime_subfolder=False",
         "--config.subfolder_name=NONE",
-        "--config.vmc.optimizer_type=proxsr",
+        "--config.vmc.optimizer_type=sgd",
     ]
     reload_argv = [
         "vmc-molecule",
@@ -200,33 +200,24 @@ def test_reload_append(mocker, tmp_path):
         energies2 = np.array(f.readlines(), dtype=float)
 
     all_dists=[[[tree_dist(states1[i][k],states2[j][k]) for j in common] for i in common] for k in range(5)]
-    dists_data=[[tree_dist(states1[i][1],states2[j][1]) for j in common] for i in common]
-    dists_params=[[tree_dist(states1[i][2],states2[j][2]) for j in common] for i in common]
-    dists_energy=(energies1[4:,None]-energies2[None,4:])**2
+    names = ('epoch', 'data', 'old_params', 'optimizer_state', 'key')
+    
+    eps=1e-6
+    try:
+        for k,name in enumerate(names):
+            distmatrix=all_dists[k]
+            assert(np.mean(np.diag(distmatrix))<eps*np.mean(distmatrix))
+            print('test passed for',name)
 
-    if True:
+    except:
         import matplotlib.pyplot as plt
-        fig,axs=plt.subplots(1,3)
-        #axs[0].imshow(dists_params)
-        #axs[1].imshow(dists_data)
-        #axs[2].imshow(dists_energy)
 
-        fig,axs=plt.subplots(1,6)
-        for k in range(5):
+        fig,axs=plt.subplots(6)
+        for k,name in enumerate(names):
             axs[k].imshow(all_dists[k])
-        axs[5].imshow(dists_energy)
+            axs[k].set_title(name)
+        axs[5].plot(energies1)
+        axs[5].plot(energies2)
         plt.show()
         breakpoint()
-    
-
-    ## check that the error from reloading vs a continuous run
-    ## is comparable to the error between identical runs
-    #assert(tree_dist(params1,params2)<10*tree_dist(params0,params1))
-
-    ## check that the error from reloading vs a continuous run
-    ## is comparable to the error between identical reloads
-    #assert(tree_dist(params1,params2)<10*tree_dist(params2,params3))
-
-
-    #np.testing.assert_allclose(energies1, energies2, rtol=1e-3)
 

--- a/tests/integrations/train/test_runners.py
+++ b/tests/integrations/train/test_runners.py
@@ -8,7 +8,6 @@ import pytest
 import vmcnet.train as train
 from ml_collections import ConfigDict
 
-from vmcnet.utils import io
 from absl import flags
 
 
@@ -142,22 +141,21 @@ def test_run_molecule_jitted(mocker, tmp_path):
 
 @pytest.mark.very_slow
 def test_reload_append(mocker, tmp_path):
-
     mocker.patch("os.curdir", tmp_path)
-    path1=(tmp_path / "run_1").as_posix()
-    path2=(tmp_path / "run_2").as_posix()
+    path1 = (tmp_path / "run_1").as_posix()
+    path2 = (tmp_path / "run_2").as_posix()
 
-    mock_argv1=[
+    mock_argv1 = [
         "vmc-molecule",
         "--presets.name=quicktest",
-        "--config.vmc.nchains="+str(2*jax.local_device_count()),
+        "--config.vmc.nchains=" + str(2 * jax.local_device_count()),
         "--config.vmc.nburn=10",
         "--config.vmc.nepochs=10",
         "--config.eval.nburn=0",
         "--config.eval.nepochs=0",
         "--config.vmc.checkpoint_every=5",
         "--config.save_to_current_datetime_subfolder=False",
-        "--config.logdir="+path1,
+        "--config.logdir=" + path1,
         "--config.subfolder_name=NONE",
     ]
     mocker.patch("sys.argv", mock_argv1)
@@ -166,22 +164,22 @@ def test_reload_append(mocker, tmp_path):
     for name in list(flags.FLAGS):
         delattr(flags.FLAGS, name)
 
-    mock_argv2=[
+    mock_argv2 = [
         "vmc-molecule",
-        "--reload.logdir="+path1,
+        "--reload.logdir=" + path1,
         "--reload.append=True",
         "--reload.checkpoint_relative_file_path=checkpoints/5.npz",
         "--config.save_to_current_datetime_subfolder=False",
-        "--config.logdir="+path2,
+        "--config.logdir=" + path2,
         "--config.subfolder_name=NONE",
     ]
     mocker.patch("sys.argv", mock_argv2)
     train.runners.run_molecule()
 
-    with open(path1+'/energy.txt','r') as f:
-        energies1=np.array(f.readlines(),dtype=float)
+    with open(path1 + "/energy.txt", "r") as f:
+        energies1 = np.array(f.readlines(), dtype=float)
 
-    with open(path2+'/energy.txt','r') as f:
-        energies2=np.array(f.readlines(),dtype=float)
+    with open(path2 + "/energy.txt", "r") as f:
+        energies2 = np.array(f.readlines(), dtype=float)
 
-    np.testing.assert_allclose(energies1,energies2,rtol=1e-5)
+    np.testing.assert_allclose(energies1, energies2, rtol=1e-5)

--- a/tests/integrations/train/test_runners.py
+++ b/tests/integrations/train/test_runners.py
@@ -15,7 +15,7 @@ def _get_config(vmc_nchains, eval_nchains, distribute):
     config.vmc.nepochs = 5
     config.vmc.nburn = 2
     config.vmc.checkpoint_every = 2
-    config.vmc.moving_checkpoints_every = 4
+    config.vmc.best_checkpoint_every = 4
     config.vmc.nsteps_per_param_update = 3
 
     config.eval.nchains = eval_nchains

--- a/tests/integrations/train/test_runners.py
+++ b/tests/integrations/train/test_runners.py
@@ -192,25 +192,29 @@ def test_reload_append(mocker, tmp_path):
     for f in sorted(os.listdir(path2+'/checkpoints'),key=lambda x:int(x.split('.')[0])):
         states2[f]=io.reload_vmc_state(path2+'/checkpoints',f)
 
-    params1={f:state[2]['params'] for f,state in states1.items()}
-    params2={f:state[2]['params'] for f,state in states2.items()}
-
-    common=[f for f in params1.keys() if f in params2.keys()]
-    dists=[[tree_dist(params1[i],params2[j]) for j in common] for i in common]
+    common=[f for f in states1.keys() if f in states2.keys()]
 
     with open(path1 + "/energy.txt", "r") as f:
         energies1 = np.array(f.readlines(), dtype=float)
-
     with open(path2 + "/energy.txt", "r") as f:
         energies2 = np.array(f.readlines(), dtype=float)
 
-    errs=(energies1[:,None]-energies2[None,:])**2
+    all_dists=[[[tree_dist(states1[i][k],states2[j][k]) for j in common] for i in common] for k in range(5)]
+    dists_data=[[tree_dist(states1[i][1],states2[j][1]) for j in common] for i in common]
+    dists_params=[[tree_dist(states1[i][2],states2[j][2]) for j in common] for i in common]
+    dists_energy=(energies1[4:,None]-energies2[None,4:])**2
 
     if True:
         import matplotlib.pyplot as plt
-        fig,axs=plt.subplots(2)
-        axs[0].imshow(dists)
-        axs[1].imshow(errs)
+        fig,axs=plt.subplots(1,3)
+        #axs[0].imshow(dists_params)
+        #axs[1].imshow(dists_data)
+        #axs[2].imshow(dists_energy)
+
+        fig,axs=plt.subplots(1,6)
+        for k in range(5):
+            axs[k].imshow(all_dists[k])
+        axs[5].imshow(dists_energy)
         plt.show()
         breakpoint()
     

--- a/tests/integrations/train/test_runners.py
+++ b/tests/integrations/train/test_runners.py
@@ -15,7 +15,7 @@ def _get_config(vmc_nchains, eval_nchains, distribute):
     config.vmc.nepochs = 5
     config.vmc.nburn = 2
     config.vmc.checkpoint_every = 2
-    config.vmc.best_checkpoint_every = 4
+    config.vmc.moving_checkpoints_every = 4
     config.vmc.nsteps_per_param_update = 3
 
     config.eval.nchains = eval_nchains

--- a/tests/integrations/train/test_runners.py
+++ b/tests/integrations/train/test_runners.py
@@ -204,21 +204,9 @@ def test_reload_append(mocker, tmp_path):
     names = ('epoch', 'data', 'old_params', 'optimizer_state', 'key')
     
     eps=1e-6
-    try:
-        for k,name in enumerate(names):
-            distmatrix=all_dists[k]
-            assert(np.mean(np.diag(distmatrix))<eps*np.mean(distmatrix))
-            print('test passed for',name)
+    for k,name in enumerate(names):
+        distmatrix=all_dists[k]
+        assert(np.mean(np.diag(distmatrix))<eps*np.mean(distmatrix))
+        print('test passed for',name)
 
-    except:
-        import matplotlib.pyplot as plt
-
-        fig,axs=plt.subplots(6)
-        for k,name in enumerate(names):
-            axs[k].imshow(all_dists[k])
-            axs[k].set_title(name)
-        axs[5].plot(energies1)
-        axs[5].plot(energies2)
-        plt.show()
-        breakpoint()
-
+    np.assert_allclose(energies1, energies2, rtol=1e-6)

--- a/tests/integrations/train/test_runners.py
+++ b/tests/integrations/train/test_runners.py
@@ -164,7 +164,8 @@ def test_reload_append(mocker, tmp_path):
         "--config.vmc.checkpoint_every=1",
         "--config.save_to_current_datetime_subfolder=False",
         "--config.subfolder_name=NONE",
-        "--config.vmc.optimizer_type=sgd",
+        "--config.vmc.optimizer_type=proxsr",
+        "--config.distribute=False",
     ]
     reload_argv = [
         "vmc-molecule",

--- a/tests/integrations/train/test_runners.py
+++ b/tests/integrations/train/test_runners.py
@@ -91,7 +91,7 @@ def _run_and_check_output_files(mocker, tmp_path, config):
             for i in range(num_regular_checkpoints)
         ]
     )
-    assert (inner_logdir / "checkpoint.npz").exists()
+    assert (inner_logdir / "best_checkpoint.npz").exists()
 
     # Check that evaluation is being done and metrics are being saved
     assert (inner_logdir / "eval").exists()

--- a/tests/units/utils/test_checkpoint.py
+++ b/tests/units/utils/test_checkpoint.py
@@ -84,7 +84,7 @@ def test_save_best_checkpoint(mocker):
     def track_and_save_best(
         epoch, checkpoint_writer, checkpoint_metric, best_checkpoint_data
     ):
-        moving_checkpoints_every = 3
+        best_checkpoint_every = 3
         return checkpoint.track_and_save_best_checkpoint(
             epoch,
             params,
@@ -99,7 +99,7 @@ def test_save_best_checkpoint(mocker):
             log_dir,
             1.0,
             "",
-            moving_checkpoints_every,
+            best_checkpoint_every,
             best_checkpoint_data,
         )
 

--- a/tests/units/utils/test_checkpoint.py
+++ b/tests/units/utils/test_checkpoint.py
@@ -84,7 +84,7 @@ def test_save_best_checkpoint(mocker):
     def track_and_save_best(
         epoch, checkpoint_writer, checkpoint_metric, best_checkpoint_data
     ):
-        best_checkpoint_every = 3
+        moving_checkpoints_every = 3
         return checkpoint.track_and_save_best_checkpoint(
             epoch,
             params,
@@ -99,7 +99,7 @@ def test_save_best_checkpoint(mocker):
             log_dir,
             1.0,
             "",
-            best_checkpoint_every,
+            moving_checkpoints_every,
             best_checkpoint_data,
         )
 
@@ -123,8 +123,8 @@ def test_save_best_checkpoint(mocker):
 
     # Checkpoints should only be saved from epochs 1 and 5
     expected_calls = [
-        (log_dir, checkpoint.CHECKPOINT_FILE_NAME, _get_fake_checkpoint_data(1)),
-        (log_dir, checkpoint.CHECKPOINT_FILE_NAME, _get_fake_checkpoint_data(5)),
+        (log_dir, checkpoint.BEST_CHECKPOINT_FILE_NAME, _get_fake_checkpoint_data(1)),
+        (log_dir, checkpoint.BEST_CHECKPOINT_FILE_NAME, _get_fake_checkpoint_data(5)),
     ]
     _assert_checkpoint_save_calls_equal(
         mock_save_checkpoint.call_args_list, expected_calls

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -81,6 +81,7 @@ def get_default_config() -> ConfigDict:
                 # if save_to_current_datetime_subfolder=True, will log into a subfolder
                 # named according to the datetime at start
                 "save_to_current_datetime_subfolder": True,
+                "subfolder_name": NO_NAME,
                 "logging_level": "INFO",
                 "dtype": "float32",
                 "distribute": True,

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -59,6 +59,7 @@ def get_default_reload_config() -> ConfigDict:
             "reset_optimizer": False,
             "reburn": False,
             "append": True,
+            "same_logdir": False,
         }
     )
 

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 from ml_collections import ConfigDict, FieldReference
 
-from vmcnet.utils.checkpoint import RECENT_CHECKPOINT_FILE_NAME
+from vmcnet.utils.checkpoint import DEFAULT_CHECKPOINT_FILE_NAME
 
 NO_NAME = "NONE"
 NO_PATH = "NONE"
@@ -55,7 +55,7 @@ def get_default_reload_config() -> ConfigDict:
             "use_config_file": True,
             "config_relative_file_path": DEFAULT_CONFIG_FILE_NAME,
             "use_checkpoint_file": True,
-            "checkpoint_relative_file_path": RECENT_CHECKPOINT_FILE_NAME,
+            "checkpoint_relative_file_path": DEFAULT_CHECKPOINT_FILE_NAME,
             "new_optimizer": False,
             "reburn": False,
             "append": True,
@@ -300,7 +300,7 @@ def get_default_vmc_config() -> Dict:
         "local_energy_type": "standard",  # [standard, ibp, random_particle]
         "local_energy": get_default_local_energy_config(),
         "checkpoint_every": 5000,
-        "moving_checkpoints_every": 100,
+        "best_checkpoint_every": 100,
         "checkpoint_dir": "checkpoints",
         "checkpoint_variance_scale": 10,
         "check_for_nans": False,

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 from ml_collections import ConfigDict, FieldReference
 
-from vmcnet.utils.checkpoint import BEST_CHECKPOINT_FILE_NAME, RECENT_CHECKPOINT_FILE_NAME
+from vmcnet.utils.checkpoint import RECENT_CHECKPOINT_FILE_NAME
 
 NO_NAME = "NONE"
 NO_PATH = "NONE"
@@ -56,7 +56,7 @@ def get_default_reload_config() -> ConfigDict:
             "config_relative_file_path": DEFAULT_CONFIG_FILE_NAME,
             "use_checkpoint_file": True,
             "checkpoint_relative_file_path": RECENT_CHECKPOINT_FILE_NAME,
-            "reset_optimizer": False,
+            "new_optimizer": False,
             "reburn": False,
             "append": True,
             "same_logdir": False,

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -56,7 +56,9 @@ def get_default_reload_config() -> ConfigDict:
             "config_relative_file_path": DEFAULT_CONFIG_FILE_NAME,
             "use_checkpoint_file": True,
             "checkpoint_relative_file_path": CHECKPOINT_FILE_NAME,
-            "model_params_only": False,
+            "reset_optimizer": False,
+            "reburn": False,
+            "append": True,
         }
     )
 

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -56,7 +56,7 @@ def get_default_reload_config() -> ConfigDict:
             "config_relative_file_path": DEFAULT_CONFIG_FILE_NAME,
             "use_checkpoint_file": True,
             "checkpoint_relative_file_path": DEFAULT_CHECKPOINT_FILE_NAME,
-            "new_optimizer": False,
+            "new_optimizer_state": False,
             "reburn": False,
             "append": True,
             "same_logdir": False,

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 from ml_collections import ConfigDict, FieldReference
 
-from vmcnet.utils.checkpoint import CHECKPOINT_FILE_NAME
+from vmcnet.utils.checkpoint import BEST_CHECKPOINT_FILE_NAME, RECENT_CHECKPOINT_FILE_NAME
 
 NO_NAME = "NONE"
 NO_PATH = "NONE"
@@ -55,7 +55,7 @@ def get_default_reload_config() -> ConfigDict:
             "use_config_file": True,
             "config_relative_file_path": DEFAULT_CONFIG_FILE_NAME,
             "use_checkpoint_file": True,
-            "checkpoint_relative_file_path": CHECKPOINT_FILE_NAME,
+            "checkpoint_relative_file_path": RECENT_CHECKPOINT_FILE_NAME,
             "reset_optimizer": False,
             "reburn": False,
             "append": True,
@@ -297,7 +297,7 @@ def get_default_vmc_config() -> Dict:
         "local_energy_type": "standard",  # [standard, ibp, random_particle]
         "local_energy": get_default_local_energy_config(),
         "checkpoint_every": 5000,
-        "best_checkpoint_every": 100,
+        "moving_checkpoints_every": 100,
         "checkpoint_dir": "checkpoints",
         "checkpoint_variance_scale": 10,
         "check_for_nans": False,

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -90,6 +90,7 @@ def get_default_config() -> ConfigDict:
             }
         )
     )
+    config.base_logdir = config.logdir
     return config
 
 

--- a/vmcnet/train/parse_config_flags.py
+++ b/vmcnet/train/parse_config_flags.py
@@ -20,6 +20,7 @@ def _get_config_from_reload(
     reloaded_config = io.load_config_dict(
         reload_config.logdir, reload_config.config_relative_file_path
     )
+    reloaded_config.logdir=reloaded_config.base_logdir
     config_flags.DEFINE_config_dict(
         "config", reloaded_config, lock_config=True, flag_values=flag_values
     )
@@ -45,7 +46,6 @@ def _get_config_from_default_config(
     flag_values(sys.argv)
     config = flag_values.config
     config.model = train.default_config.choose_model_type_in_model_config(config.model)
-    config.lock()
     return config
 
 
@@ -137,4 +137,6 @@ def parse_flags(flag_values: flags.FlagValues) -> Tuple[ConfigDict, ConfigDict]:
         config.distribute = False
         jax.config.update("jax_debug_nans", True)
 
+    config.base_logdir = config.logdir
+    config.lock()
     return reload_config, config

--- a/vmcnet/train/parse_config_flags.py
+++ b/vmcnet/train/parse_config_flags.py
@@ -20,7 +20,7 @@ def _get_config_from_reload(
     reloaded_config = io.load_config_dict(
         reload_config.logdir, reload_config.config_relative_file_path
     )
-    reloaded_config.logdir=reloaded_config.base_logdir
+    reloaded_config.logdir = reloaded_config.base_logdir
     config_flags.DEFINE_config_dict(
         "config", reloaded_config, lock_config=True, flag_values=flag_values
     )

--- a/vmcnet/train/parse_config_flags.py
+++ b/vmcnet/train/parse_config_flags.py
@@ -119,7 +119,7 @@ def parse_flags(flag_values: flags.FlagValues) -> Tuple[ConfigDict, ConfigDict]:
 
     if flag_values.presets.name != NO_NAME:
         presets_path = os.path.join(
-            io.get_vmcpath(), DEFAULT_PRESETS_DIR, flag_values.presets.name + ".json"
+            DEFAULT_PRESETS_DIR, flag_values.presets.name + ".json"
         )
     elif flag_values.presets.path != NO_PATH:
         presets_path = flag_values.presets.path

--- a/vmcnet/train/parse_config_flags.py
+++ b/vmcnet/train/parse_config_flags.py
@@ -119,7 +119,7 @@ def parse_flags(flag_values: flags.FlagValues) -> Tuple[ConfigDict, ConfigDict]:
 
     if flag_values.presets.name != NO_NAME:
         presets_path = os.path.join(
-            DEFAULT_PRESETS_DIR, flag_values.presets.name + ".json"
+            io.get_vmcpath(), DEFAULT_PRESETS_DIR, flag_values.presets.name + ".json"
         )
     elif flag_values.presets.path != NO_PATH:
         presets_path = flag_values.presets.path

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -595,7 +595,7 @@ def run_molecule() -> None:
         config.notes = config.notes + " (reloaded from {}/{}{})".format(
             reload_config.logdir,
             reload_config.checkpoint_relative_file_path,
-            ", new optimizer" if reload_config.new_optimizer else "",
+            ", new optimizer state" if reload_config.new_optimizer_state else "",
         )
 
     root_logger = logging.getLogger()
@@ -662,7 +662,7 @@ def run_molecule() -> None:
             data, params, reloaded_optimizer_state, key
         )
 
-        if not reload_config.new_optimizer:
+        if not reload_config.new_optimizer_state:
             optimizer_state = reloaded_optimizer_state
 
     logging.info("Saving to %s", logdir)

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -653,14 +653,15 @@ def run_molecule() -> None:
                 reload_config.logdir, logdir, truncate=reload_at_epoch
             )
 
-        (
-            data,
-            params,
-            reloaded_optimizer_state,
-            key,
-        ) = utils.distribute.distribute_vmc_state_from_checkpoint(
-            data, params, reloaded_optimizer_state, key
-        )
+        if config.distribute:
+            (
+                data,
+                params,
+                reloaded_optimizer_state,
+                key,
+            ) = utils.distribute.distribute_vmc_state_from_checkpoint(
+                data, params, reloaded_optimizer_state, key
+            )
 
         if not reload_config.new_optimizer_state:
             optimizer_state = reloaded_optimizer_state

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -525,14 +525,14 @@ def _burn_and_run_vmc(
 ) -> Tuple[P, S, D, PRNGKey, bool]:
     if not is_eval:
         checkpoint_every = run_config.checkpoint_every
-        best_checkpoint_every = run_config.best_checkpoint_every
+        moving_checkpoints_every = run_config.moving_checkpoints_every
         checkpoint_dir = run_config.checkpoint_dir
         checkpoint_variance_scale = run_config.checkpoint_variance_scale
         nhistory_max = run_config.nhistory_max
         check_for_nans = run_config.check_for_nans
     else:
         checkpoint_every = None
-        best_checkpoint_every = None
+        moving_checkpoints_every = None
         checkpoint_dir = ""
         checkpoint_variance_scale = 0
         nhistory_max = 0
@@ -553,7 +553,7 @@ def _burn_and_run_vmc(
         key,
         logdir=logdir,
         checkpoint_every=checkpoint_every,
-        best_checkpoint_every=best_checkpoint_every,
+        moving_checkpoints_every=moving_checkpoints_every,
         checkpoint_dir=checkpoint_dir,
         checkpoint_variance_scale=checkpoint_variance_scale,
         check_for_nans=check_for_nans,
@@ -644,6 +644,7 @@ def run_molecule() -> None:
 
         if reload_config.append:
             start_epoch=reload_at_epoch
+            utils.io.copy_txt_stats(reload_config.logdir, logdir, truncate=reload_at_epoch)
 
         (
             data,

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -41,15 +41,18 @@ FLAGS = flags.FLAGS
 
 
 def _get_logdir_and_save_config(reload_config: ConfigDict, config: ConfigDict) -> str:
-    if config.save_to_current_datetime_subfolder:
-        config.logdir = os.path.join(
-            config.logdir, datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-        )
 
-    config.logdir = utils.io.add_suffix_for_uniqueness(config.logdir)
+    if reload_config.same_logdir:
+        config.logdir = reload_config.logdir
+    else:
+        if config.save_to_current_datetime_subfolder:
+            config.logdir = os.path.join(
+                config.logdir, datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+            )
+        config.logdir = utils.io.add_suffix_for_uniqueness(config.logdir)
+
     utils.io.save_config_dict_to_json(config, config.logdir, "config")
     utils.io.save_config_dict_to_json(reload_config, config.logdir, "reload_config")
-
     logging.info("Reload configuration: \n%s", reload_config)
     logging.info("Running with configuration: \n%s", config)
     return config.logdir
@@ -592,7 +595,6 @@ def run_molecule() -> None:
             reload_config.logdir, reload_config.checkpoint_relative_file_path,
             ", new optimizer" if reload_config.reset_optimizer else ""
         )
-
 
     root_logger = logging.getLogger()
     root_logger.setLevel(config.logging_level)

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -45,18 +45,14 @@ def _get_logdir_and_save_config(reload_config: ConfigDict, config: ConfigDict) -
     logging.info("Running with configuration: \n%s", config)
     if config.logdir:
         if config.save_to_current_datetime_subfolder:
-            dirname = utils.io.add_suffix_for_uniqueness(
-                name=datetime.datetime.now().strftime("%Y%m%d-%H%M%S"),
-                logdir=config.logdir,
-            )
-            config.logdir = os.path.join(config.logdir, dirname)
+            config.logdir = os.path.join(config.logdir, datetime.datetime.now().strftime("%Y%m%d-%H%M%S"))
 
-        logdir = config.logdir
-        utils.io.save_config_dict_to_json(config, logdir, "config")
-        utils.io.save_config_dict_to_json(reload_config, logdir, "reload_config")
+        config.logdir = utils.io.add_suffix_for_uniqueness(config.logdir)
+        utils.io.save_config_dict_to_json(config, config.logdir, "config")
+        utils.io.save_config_dict_to_json(reload_config, config.logdir, "reload_config")
+        return config.logdir
     else:
-        logdir = None
-    return logdir
+        return None
 
 
 def _save_git_hash(logdir):

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -648,7 +648,6 @@ def run_molecule() -> None:
         ) = utils.io.reload_vmc_state(directory, filename)
 
         if reload_config.append:
-            start_epoch = reload_at_epoch
             utils.io.copy_txt_stats(
                 reload_config.logdir, logdir, truncate=reload_at_epoch
             )
@@ -665,6 +664,7 @@ def run_molecule() -> None:
 
         if not reload_config.new_optimizer_state:
             optimizer_state = reloaded_optimizer_state
+            start_epoch = reload_at_epoch
 
     logging.info("Saving to %s", logdir)
 

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -44,10 +44,8 @@ def _get_logdir_and_save_config(reload_config: ConfigDict, config: ConfigDict) -
     if reload_config.same_logdir:
         config.logdir = reload_config.logdir
     else:
-        if config.subfolder_name!=train.default_config.NO_NAME:
-            config.logdir = os.path.join(
-                config.logdir, config.subfolder_name
-            )
+        if config.subfolder_name != train.default_config.NO_NAME:
+            config.logdir = os.path.join(config.logdir, config.subfolder_name)
         if config.save_to_current_datetime_subfolder:
             config.logdir = os.path.join(
                 config.logdir, datetime.datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -44,6 +44,10 @@ def _get_logdir_and_save_config(reload_config: ConfigDict, config: ConfigDict) -
     if reload_config.same_logdir:
         config.logdir = reload_config.logdir
     else:
+        if config.subfolder_name!=train.default_config.NO_NAME:
+            config.logdir = os.path.join(
+                config.logdir, config.subfolder_name
+            )
         if config.save_to_current_datetime_subfolder:
             config.logdir = os.path.join(
                 config.logdir, datetime.datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -42,7 +42,9 @@ FLAGS = flags.FLAGS
 
 def _get_logdir_and_save_config(reload_config: ConfigDict, config: ConfigDict) -> str:
     if config.save_to_current_datetime_subfolder:
-        config.logdir = os.path.join(config.logdir, datetime.datetime.now().strftime("%Y%m%d-%H%M%S"))
+        config.logdir = os.path.join(
+            config.logdir, datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+        )
 
     config.logdir = utils.io.add_suffix_for_uniqueness(config.logdir)
     utils.io.save_config_dict_to_json(config, config.logdir, "config")

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -529,14 +529,14 @@ def _burn_and_run_vmc(
 ) -> Tuple[P, S, D, PRNGKey, bool]:
     if not is_eval:
         checkpoint_every = run_config.checkpoint_every
-        moving_checkpoints_every = run_config.moving_checkpoints_every
+        best_checkpoint_every = run_config.best_checkpoint_every
         checkpoint_dir = run_config.checkpoint_dir
         checkpoint_variance_scale = run_config.checkpoint_variance_scale
         nhistory_max = run_config.nhistory_max
         check_for_nans = run_config.check_for_nans
     else:
         checkpoint_every = None
-        moving_checkpoints_every = None
+        best_checkpoint_every = None
         checkpoint_dir = ""
         checkpoint_variance_scale = 0
         nhistory_max = 0
@@ -557,7 +557,7 @@ def _burn_and_run_vmc(
         key,
         logdir=logdir,
         checkpoint_every=checkpoint_every,
-        moving_checkpoints_every=moving_checkpoints_every,
+        best_checkpoint_every=best_checkpoint_every,
         checkpoint_dir=checkpoint_dir,
         checkpoint_variance_scale=checkpoint_variance_scale,
         check_for_nans=check_for_nans,

--- a/vmcnet/train/vmc.py
+++ b/vmcnet/train/vmc.py
@@ -21,7 +21,7 @@ def vmc_loop(
     key: PRNGKey,
     logdir: Optional[str] = None,
     checkpoint_every: Optional[int] = 1000,
-    moving_checkpoints_every: Optional[int] = 100,
+    best_checkpoint_every: Optional[int] = 100,
     checkpoint_dir: str = "checkpoints",
     checkpoint_variance_scale: float = 10.0,
     check_for_nans: bool = False,
@@ -63,14 +63,12 @@ def vmc_loop(
         checkpoint_every (int, optional): how often to regularly save checkpoints. If
             None, checkpoints are only saved when the error-adjusted running avg of the
             energy improves. Defaults to 1000.
-        moving_checkpoints_every (int, optional): limit on how often to save recent
-            checkpoint and best checkpoint.
-            Best checkpoint is saved even if energy is improving. When the error-
-            adjusted running avg of the energy improves, instead of immediately saving
-            a checkpoint, we hold onto the data from that epoch in memory,
-            and if it's still the best one when we hit an epoch which is a multiple of
-            `moving_checkpoints_every`, we save it then.
-            This ensures we don't waste time saving best checkpoints too often
+        best_checkpoint_every (int, optional): limit on how often to save best
+            checkpoint, even if energy is improving. When the error-adjusted running avg
+            of the energy improves, instead of immediately saving a checkpoint, we hold
+            onto the data from that epoch in memory, and if it's still the best one when
+            we hit an epoch which is a multiple of `best_checkpoint_every`, we save it
+            then. This ensures we don't waste time saving best checkpoints too often
             when the energy is on a downward trajectory (as we hope it often is!).
             Defaults to 100.
         checkpoint_dir (str, optional): name of subdirectory to save the regular
@@ -150,7 +148,7 @@ def vmc_loop(
                 logdir=logdir,
                 variance_scale=checkpoint_variance_scale,
                 checkpoint_every=checkpoint_every,
-                moving_checkpoints_every=moving_checkpoints_every,
+                best_checkpoint_every=best_checkpoint_every,
                 best_checkpoint_data=best_checkpoint_data,
                 checkpoint_dir=checkpoint_dir,
                 check_for_nans=check_for_nans,

--- a/vmcnet/train/vmc.py
+++ b/vmcnet/train/vmc.py
@@ -29,6 +29,7 @@ def vmc_loop(
     get_amplitude_fn: Optional[GetAmplitudeFromData[D]] = None,
     nhistory_max: int = 200,
     is_pmapped=True,
+    start_epoch: int = 0,
 ) -> Tuple[P, S, D, PRNGKey, bool]:
     """Main Variational Monte Carlo loop routine.
 
@@ -101,7 +102,7 @@ def vmc_loop(
     with CheckpointWriter(
         is_pmapped
     ) as checkpoint_writer, MetricsWriter() as metrics_writer:
-        for epoch in range(nepochs):
+        for epoch in range(start_epoch,nepochs):
             # Save state for checkpointing at the start of the epoch for two reasons:
             # 1. To save the model that generates the best energy and variance metrics,
             # rather than the model one parameter UPDATE after the best metrics.

--- a/vmcnet/train/vmc.py
+++ b/vmcnet/train/vmc.py
@@ -21,7 +21,7 @@ def vmc_loop(
     key: PRNGKey,
     logdir: Optional[str] = None,
     checkpoint_every: Optional[int] = 1000,
-    best_checkpoint_every: Optional[int] = 100,
+    moving_checkpoints_every: Optional[int] = 100,
     checkpoint_dir: str = "checkpoints",
     checkpoint_variance_scale: float = 10.0,
     check_for_nans: bool = False,
@@ -63,11 +63,12 @@ def vmc_loop(
         checkpoint_every (int, optional): how often to regularly save checkpoints. If
             None, checkpoints are only saved when the error-adjusted running avg of the
             energy improves. Defaults to 1000.
-        best_checkpoint_every (int, optional): limit on how often to save best
-            checkpoint, even if energy is improving. When the error-adjusted running avg
-            of the energy improves, instead of immediately saving a checkpoint, we hold
+        moving_checkpoints_every (int, optional): limit on how often to save recent
+            checkpoint and best checkpoint.
+            Best checkpoint is saved even if energy is improving. When the error-adjusted
+            running avg of the energy improves, instead of immediately saving a checkpoint, we hold
             onto the data from that epoch in memory, and if it's still the best one when
-            we hit an epoch which is a multiple of `best_checkpoint_every`, we save it
+            we hit an epoch which is a multiple of `moving_checkpoints_every`, we save it
             then. This ensures we don't waste time saving best checkpoints too often
             when the energy is on a downward trajectory (as we hope it often is!).
             Defaults to 100.
@@ -148,7 +149,7 @@ def vmc_loop(
                 logdir=logdir,
                 variance_scale=checkpoint_variance_scale,
                 checkpoint_every=checkpoint_every,
-                best_checkpoint_every=best_checkpoint_every,
+                moving_checkpoints_every=moving_checkpoints_every,
                 best_checkpoint_data=best_checkpoint_data,
                 checkpoint_dir=checkpoint_dir,
                 check_for_nans=check_for_nans,

--- a/vmcnet/train/vmc.py
+++ b/vmcnet/train/vmc.py
@@ -65,11 +65,12 @@ def vmc_loop(
             energy improves. Defaults to 1000.
         moving_checkpoints_every (int, optional): limit on how often to save recent
             checkpoint and best checkpoint.
-            Best checkpoint is saved even if energy is improving. When the error-adjusted
-            running avg of the energy improves, instead of immediately saving a checkpoint, we hold
-            onto the data from that epoch in memory, and if it's still the best one when
-            we hit an epoch which is a multiple of `moving_checkpoints_every`, we save it
-            then. This ensures we don't waste time saving best checkpoints too often
+            Best checkpoint is saved even if energy is improving. When the error-
+            adjusted running avg of the energy improves, instead of immediately saving
+            a checkpoint, we hold onto the data from that epoch in memory,
+            and if it's still the best one when we hit an epoch which is a multiple of
+            `moving_checkpoints_every`, we save it then.
+            This ensures we don't waste time saving best checkpoints too often
             when the energy is on a downward trajectory (as we hope it often is!).
             Defaults to 100.
         checkpoint_dir (str, optional): name of subdirectory to save the regular
@@ -103,7 +104,7 @@ def vmc_loop(
     with CheckpointWriter(
         is_pmapped
     ) as checkpoint_writer, MetricsWriter() as metrics_writer:
-        for epoch in range(start_epoch,nepochs):
+        for epoch in range(start_epoch, nepochs):
             # Save state for checkpointing at the start of the epoch for two reasons:
             # 1. To save the model that generates the best energy and variance metrics,
             # rather than the model one parameter UPDATE after the best metrics.

--- a/vmcnet/utils/checkpoint.py
+++ b/vmcnet/utils/checkpoint.py
@@ -611,7 +611,7 @@ def save_metrics_and_regular_checkpoint(
         if (epoch + 1) % checkpoint_every == 0:
             checkpoint_writer.save_data(
                 os.path.join(logdir, checkpoint_dir),
-                str(epoch) + ".npz",
+                str(epoch + 1) + ".npz",
                 checkpoint_data,
             )
             checkpoint_str = checkpoint_str + ", regular ckpt saved"
@@ -632,7 +632,7 @@ def save_metrics_and_regular_checkpoint(
     if nans_detected:
         checkpoint_writer.save_data(
             os.path.join(logdir, checkpoint_dir),
-            "nans_" + str(epoch) + ".npz",
+            "nans_" + str(epoch + 1) + ".npz",
             checkpoint_data,
         )
         checkpoint_str = checkpoint_str + ", nans ckpt saved"

--- a/vmcnet/utils/checkpoint.py
+++ b/vmcnet/utils/checkpoint.py
@@ -537,7 +537,7 @@ def track_and_save_best_checkpoint(
                 key,
             )
 
-        should_save_best_checkpoint = epoch % moving_checkpoints_every == 0 and epoch > 0
+        should_save_best_checkpoint = (epoch + 1) % moving_checkpoints_every == 0
         if should_save_best_checkpoint and best_checkpoint_data is not None:
             checkpoint_writer.save_data(
                 logdir, BEST_CHECKPOINT_FILE_NAME, best_checkpoint_data
@@ -604,7 +604,7 @@ def save_metrics_and_regular_checkpoint(
     checkpoint_data = (epoch, data, old_params, optimizer_state, key)
 
     if checkpoint_every is not None:
-        if epoch % checkpoint_every == 0 and epoch>0:
+        if (epoch + 1) % checkpoint_every == 0:
             checkpoint_writer.save_data(
                 os.path.join(logdir, checkpoint_dir),
                 str(epoch) + ".npz",
@@ -613,13 +613,13 @@ def save_metrics_and_regular_checkpoint(
             checkpoint_str = checkpoint_str + ", regular ckpt saved"
 
     if recent_checkpoint_every is not None:
-        if epoch % recent_checkpoint_every == 0 and epoch>0:
+        if (epoch + 1) % recent_checkpoint_every == 0:
             checkpoint_writer.save_data(
-                os.path.join(logdir, checkpoint_dir),
-                "recent_checkpoint.npz",
+                logdir,
+                RECENT_CHECKPOINT_FILE_NAME,
                 checkpoint_data,
             )
-            checkpoint_str = checkpoint_str + ", regular ckpt saved"
+            checkpoint_str = checkpoint_str + ", recent ckpt saved"
 
     nans_detected = False
     if check_for_nans:

--- a/vmcnet/utils/checkpoint.py
+++ b/vmcnet/utils/checkpoint.py
@@ -563,7 +563,6 @@ def save_metrics_and_regular_checkpoint(
     checkpoint_dir: str,
     checkpoint_str: str,
     checkpoint_every: Optional[int] = None,
-    recent_checkpoint_every: Optional[int] = None,
     check_for_nans: bool = False,
 ) -> Tuple[str, bool]:
     """Save current metrics to file, and save model state regularly.

--- a/vmcnet/utils/checkpoint.py
+++ b/vmcnet/utils/checkpoint.py
@@ -240,7 +240,9 @@ def finish_checkpointing(
 ):
     """Save any final checkpoint data to the CheckpointWriter."""
     if logdir is not None and best_checkpoint_data is not None:
-        checkpoint_writer.save_data(logdir, BEST_CHECKPOINT_FILE_NAME, best_checkpoint_data)
+        checkpoint_writer.save_data(
+            logdir, BEST_CHECKPOINT_FILE_NAME, best_checkpoint_data
+        )
 
 
 def _add_amplitude_to_metrics_if_requested(
@@ -367,11 +369,12 @@ def save_metrics_and_handle_checkpoints(
             the energy history
         moving_checkpoints_every (int, optional): limit on how often to save recent
             checkpoint and best checkpoint.
-            Best checkpoint is saved even if energy is improving. When the error-adjusted
-            running avg of the energy improves, instead of immediately saving a checkpoint, we hold
-            onto the data from that epoch in memory, and if it's still the best one when
-            we hit an epoch which is a multiple of `moving_checkpoints_every`, we save it
-            then. This ensures we don't waste time saving best checkpoints too often
+            Best checkpoint is saved even if energy is improving. When the error-
+            adjusted running avg of the energy improves, instead of immediately saving
+            a checkpoint, we hold onto the data from that epoch in memory,
+            and if it's still the best one when we hit an epoch which is a multiple of
+            `moving_checkpoints_every`, we save it then.
+            This ensures we don't waste time saving best checkpoints too often
             when the energy is on a downward trajectory (as we hope it often is!).
             Defaults to 100.
         logdir (str, optional): name of parent log directory. If None, no checkpointing
@@ -504,11 +507,12 @@ def track_and_save_best_checkpoint(
             occurred
         moving_checkpoints_every (int, optional): limit on how often to save recent
             checkpoint and best checkpoint.
-            Best checkpoint is saved even if energy is improving. When the error-adjusted
-            running avg of the energy improves, instead of immediately saving a checkpoint, we hold
-            onto the data from that epoch in memory, and if it's still the best one when
-            we hit an epoch which is a multiple of `moving_checkpoints_every`, we save it
-            then. This ensures we don't waste time saving best checkpoints too often
+            Best checkpoint is saved even if energy is improving. When the error-
+            adjusted running avg of the energy improves, instead of immediately saving
+            a checkpoint, we hold onto the data from that epoch in memory,
+            and if it's still the best one when we hit an epoch which is a multiple of
+            `moving_checkpoints_every`, we save it then.
+            This ensures we don't waste time saving best checkpoints too often
             when the energy is on a downward trajectory (as we hope it often is!).
             Defaults to 100.
         best_checkpoint_data (CheckpointData, optional): the data needed to save a

--- a/vmcnet/utils/checkpoint.py
+++ b/vmcnet/utils/checkpoint.py
@@ -213,7 +213,6 @@ def initialize_checkpointing(
     best checkpoint data is initialized to None.
     """
     if logdir is not None:
-        logging.info("Saving to %s", logdir)
         os.makedirs(logdir, exist_ok=True)
         if checkpoint_every is not None:
             checkpoint_dir = io.add_suffix_for_uniqueness(checkpoint_dir, logdir)

--- a/vmcnet/utils/io.py
+++ b/vmcnet/utils/io.py
@@ -36,7 +36,9 @@ def append_metric_to_file(new_metric, logdir, name):
 
 def copy_txt_stats(source_dir, target_dir, truncate=None):
     """Copies and truncated energy.txt as similar stats."""
-    filenames=[n for n in os.listdir(source_dir) if n.endswith(".txt") and "git_hash" not in n]
+    filenames = [
+        n for n in os.listdir(source_dir) if n.endswith(".txt") and "git_hash" not in n
+    ]
 
     for filename in filenames:
         source_path = os.path.join(source_dir, filename)

--- a/vmcnet/utils/io.py
+++ b/vmcnet/utils/io.py
@@ -35,6 +35,7 @@ def append_metric_to_file(new_metric, logdir, name):
 
 
 def copy_txt_stats(source_dir, target_dir, truncate=None):
+    """Copies and truncated energy.txt as similar stats."""
     names = ["energy", "energy_noclip", "variance", "variance_noclip", "accept_ratio"]
     for name in names:
         filename = name + ".txt"

--- a/vmcnet/utils/io.py
+++ b/vmcnet/utils/io.py
@@ -132,10 +132,20 @@ def process_checkpoint_data_for_saving(
 
 
 def wrap_singleton(x):
+    """Wrap tuple.
+
+    numpy.savez does not load tuples correctly,
+    so we wrap the optimizer_state.
+    """
     return {"single_element": x}
 
 
 def unwrap_if_singleton(x):
+    """Unwrap data.
+
+    numpy.savez does not load tuples correctly,
+    so we wrap the optimizer_state.
+    """
     if isinstance(x, dict) and len(x) == 1 and "single_element" in x:
         return x["single_element"]
     return x

--- a/vmcnet/utils/io.py
+++ b/vmcnet/utils/io.py
@@ -196,6 +196,6 @@ def add_suffix_for_uniqueness(relative_path, base_dir="", trailing_suffix=""):
 
 def get_vmcpath():
     """Get the path to the vmcnet package."""
-    path=os.path.dirname(os.path.abspath(__file__))
-    path=path.split('vmcnet')[0]
-    return os.path.join(path,'vmcnet')
+    path = os.path.dirname(os.path.abspath(__file__))
+    path = path.split("vmcnet")[0]
+    return os.path.join(path, "vmcnet")

--- a/vmcnet/utils/io.py
+++ b/vmcnet/utils/io.py
@@ -125,7 +125,18 @@ def process_checkpoint_data_for_saving(
     if is_distributed:
         params = get_first(params)
         optimizer_state = get_first(optimizer_state)
+    optimizer_state = wrap_singleton(optimizer_state)
     return (epoch, data, params, optimizer_state, key)
+
+
+def wrap_singleton(x):
+    return {"single_element": x}
+
+
+def unwrap_if_singleton(x):
+    if isinstance(x, dict) and len(x) == 1 and "single_element" in x:
+        return x["single_element"]
+    return x
 
 
 def save_vmc_state(directory, name, checkpoint_data: CheckpointData):
@@ -170,7 +181,7 @@ def reload_vmc_state(directory: str, name: str) -> CheckpointData:
                 data = data.tolist()
 
             params = npz_data["p"].tolist()
-            optimizer_state = npz_data["o"].tolist()
+            optimizer_state = unwrap_if_singleton(npz_data["o"].tolist())
             key = npz_data["k"]
             return (epoch, data, params, optimizer_state, key)
 

--- a/vmcnet/utils/io.py
+++ b/vmcnet/utils/io.py
@@ -34,6 +34,25 @@ def append_metric_to_file(new_metric, logdir, name):
         np.savetxt(outfile, dumped_metric)
 
 
+def copy_txt_stats(source_dir, target_dir, truncate=None):
+    names=['energy','energy_noclip','variance','variance_noclip','accept_ratio']
+    for name in names:
+        filename=name+'.txt'
+        source_path=os.path.join(source_dir,filename)
+        target_path=os.path.join(target_dir,filename)
+
+        if not os.path.exists(source_path):
+            continue
+
+        with open(source_path, "r") as f:
+            lines=f.readlines()
+            if truncate:
+                lines=lines[:truncate]
+
+        with open(target_path, "w") as f:
+            f.writelines(lines)
+
+
 def _config_dict_write(fp: IO[str], config: ConfigDict) -> None:
     """Write config dict to json."""
     fp.write(config.to_json(indent=4))

--- a/vmcnet/utils/io.py
+++ b/vmcnet/utils/io.py
@@ -192,3 +192,10 @@ def add_suffix_for_uniqueness(relative_path, base_dir="", trailing_suffix=""):
 
     # This function is for ensuring uniqueness, so it doesn't check existence
     return final_relative_path
+
+
+def get_vmcpath():
+    """Get the path to the vmcnet package."""
+    path=os.path.dirname(os.path.abspath(__file__))
+    path=path.split('vmcnet')[0]
+    return os.path.join(path,'vmcnet')

--- a/vmcnet/utils/io.py
+++ b/vmcnet/utils/io.py
@@ -155,7 +155,7 @@ def reload_vmc_state(directory: str, name: str) -> CheckpointData:
             return (epoch, data, params, optimizer_state, key)
 
 
-def add_suffix_for_uniqueness(name, logdir, trailing_suffix=""):
+def add_suffix_for_uniqueness(relative_path, base_dir="", trailing_suffix=""):
     """Adds a numerical suffix to keep names unique in a directory.
 
     Checks for the presence of name + trailing_suffix, name + "_1" + trailing_suffix,
@@ -164,13 +164,11 @@ def add_suffix_for_uniqueness(name, logdir, trailing_suffix=""):
 
     If name + trailing_suffix is not in logdir, returns name.
     """
-    final_name = name
+    final_relative_path = relative_path.rstrip(os.sep)
     i = 0
-    try:
-        while (final_name + trailing_suffix) in os.listdir(logdir):
-            i += 1
-            final_name = name + "_" + str(i)
-    except FileNotFoundError:
-        # don't do anything to the name if the directory doesn't exist
-        pass
-    return final_name
+    while os.path.exists(os.path.join(base_dir, final_relative_path + trailing_suffix)):
+        i += 1
+        final_relative_path = relative_path + "_" + str(i)
+
+    # This function is for ensuring uniqueness, so it doesn't check existence
+    return final_relative_path

--- a/vmcnet/utils/io.py
+++ b/vmcnet/utils/io.py
@@ -35,19 +35,19 @@ def append_metric_to_file(new_metric, logdir, name):
 
 
 def copy_txt_stats(source_dir, target_dir, truncate=None):
-    names=['energy','energy_noclip','variance','variance_noclip','accept_ratio']
+    names = ["energy", "energy_noclip", "variance", "variance_noclip", "accept_ratio"]
     for name in names:
-        filename=name+'.txt'
-        source_path=os.path.join(source_dir,filename)
-        target_path=os.path.join(target_dir,filename)
+        filename = name + ".txt"
+        source_path = os.path.join(source_dir, filename)
+        target_path = os.path.join(target_dir, filename)
 
         if not os.path.exists(source_path):
             continue
 
         with open(source_path, "r") as f:
-            lines=f.readlines()
+            lines = f.readlines()
             if truncate:
-                lines=lines[:truncate]
+                lines = lines[:truncate]
 
         with open(target_path, "w") as f:
             f.writelines(lines)

--- a/vmcnet/utils/io.py
+++ b/vmcnet/utils/io.py
@@ -36,9 +36,9 @@ def append_metric_to_file(new_metric, logdir, name):
 
 def copy_txt_stats(source_dir, target_dir, truncate=None):
     """Copies and truncated energy.txt as similar stats."""
-    names = ["energy", "energy_noclip", "variance", "variance_noclip", "accept_ratio"]
-    for name in names:
-        filename = name + ".txt"
+    filenames=[n for n in os.listdir(source_dir) if n.endswith(".txt") and "git_hash" not in n]
+
+    for filename in filenames:
         source_path = os.path.join(source_dir, filename)
         target_path = os.path.join(target_dir, filename)
 

--- a/vmcnet/utils/pytree_helpers.py
+++ b/vmcnet/utils/pytree_helpers.py
@@ -12,6 +12,20 @@ def tree_sum(tree1: T, tree2: T) -> T:
     return jax.tree_map(lambda a, b: a + b, tree1, tree2)
 
 
+def tree_diff(tree1: T, tree2: T) -> T:
+    """Leaf-wise sum of two pytrees with the same structure."""
+    return jax.tree_map(lambda a, b: a - b, tree1, tree2)
+
+
+def tree_dist(tree1: T, tree2: T, mode="squares") -> float:
+    """Distance between two pytrees with the same structure."""
+    dT = tree_diff(tree1, tree2)
+    if mode == "L1":
+        return tree_reduce_l1(dT)
+    if mode == "squares":
+        return tree_inner_product(dT, dT)
+
+
 def tree_prod(tree1: T, tree2: T) -> T:
     """Leaf-wise product of two pytrees with the same structure."""
     return jax.tree_map(lambda a, b: a * b, tree1, tree2)

--- a/vmcnet/utils/pytree_helpers.py
+++ b/vmcnet/utils/pytree_helpers.py
@@ -17,13 +17,12 @@ def tree_diff(tree1: T, tree2: T) -> T:
     return jax.tree_map(lambda a, b: a - b, tree1, tree2)
 
 
-def tree_dist(tree1: T, tree2: T, mode="squares") -> float:
+def tree_dist(tree1: T, tree2: T, mode="squares") -> Array:
     """Distance between two pytrees with the same structure."""
     dT = tree_diff(tree1, tree2)
-    if mode == "L1":
-        return tree_reduce_l1(dT)
     if mode == "squares":
         return tree_inner_product(dT, dT)
+    raise ValueError(f"Unknown mode {mode}")
 
 
 def tree_prod(tree1: T, tree2: T) -> T:


### PR DESCRIPTION
# Test

### pytest tests/integrations/train/test_runners.py -k 'test_reload_append' --run_very_slow

This runs an example for 10 epochs as run_1. It then reloads from the checkpoint at 5 epochs and re-runs the last epochs until 10 epochs total is reached again. The energies from the two runs are compared.

# Example

### Run for 110 epochs 
```
vmc-molecule \
  --presets.name=quicktest \
  --config.vmc.nepochs=110
```

### Discard epochs 101-110 and run epochs 101-200 as if it had been a single run of 200 epochs
```
vmc-molecule \
  --reload.logdir=logs/quicktest \
  --reload.same_logdir \
  --config.vmc.nepochs=200
```
Epochs are counted from the start of the reloaded run only if reload_config.append is True.


## Continue for 50 epochs with a new optimizer

To save in **logs/quicktest_proxsr**
```
vmc-molecule \
  --reload.logdir=logs/quicktest \
  --reload.new_optimizer \
  --config.vmc.optimizer_type=proxsr \
  --config.vmc.nepochs=250 \
  --config.subfolder_name=quicktest_proxsr
```

To save in **logs/proxsr/quicktest**
```
vmc-molecule \
  --reload.logdir=logs/quicktest \
  --reload.new_optimizer \
  --config.vmc.optimizer_type=proxsr \
  --config.vmc.nepochs=250 \
  --config.logdir=logs/proxsr
```

To avoid named subfolder behavior, do not define subfolder_name in the presets or flags