### PR TITLE
Fix double precision

### DIFF
--- a/tests/integrations/train/test_runners.py
+++ b/tests/integrations/train/test_runners.py
@@ -142,18 +142,6 @@ def test_run_molecule_jitted(mocker, tmp_path):
 
 
 @pytest.mark.very_slow
-def test_run_molecule_double_precision(mocker, tmp_path):
-    """End-to-end test of the molecular runner, in double precision."""
-    vmc_nchains = 3 * jax.local_device_count()
-    eval_nchains = 2 * jax.local_device_count()
-    mocker.patch("os.curdir", tmp_path)
-    config = _get_config(vmc_nchains, eval_nchains, False)
-    config.dtype = "float64"
-
-    _run_and_check_output_files(mocker, tmp_path, config)
-
-
-@pytest.mark.very_slow
 def test_reload_append(mocker, tmp_path):
     """Reload and continue a run from a checkpoint.
 
@@ -230,3 +218,17 @@ def test_reload_append(mocker, tmp_path):
         print("test passed for", name)
 
     np.testing.assert_allclose(energies1, energies2, rtol=1e-6)
+
+
+# NOTE (ggoldsh): This test MUST be at the end of the file, otherwise it turns on
+# double precision for later tests and causes them to fail.
+@pytest.mark.very_slow
+def test_run_molecule_double_precision(mocker, tmp_path):
+    """End-to-end test of the molecular runner, in double precision."""
+    vmc_nchains = 3 * jax.local_device_count()
+    eval_nchains = 2 * jax.local_device_count()
+    mocker.patch("os.curdir", tmp_path)
+    config = _get_config(vmc_nchains, eval_nchains, False)
+    config.dtype = "float64"
+
+    _run_and_check_output_files(mocker, tmp_path, config)

--- a/tests/integrations/train/test_runners.py
+++ b/tests/integrations/train/test_runners.py
@@ -2,6 +2,7 @@
 import os
 
 import jax
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
@@ -139,6 +140,18 @@ def test_run_molecule_jitted(mocker, tmp_path):
     config = _get_config(vmc_nchains, eval_nchains, False)
 
     _run_and_check_output_files(mocker, tmp_path, config)
+
+@pytest.mark.very_slow
+def test_run_molecule_double_precision(mocker, tmp_path):
+    """End-to-end test of the molecular runner, in double precision."""
+    vmc_nchains = 3 * jax.local_device_count()
+    eval_nchains = 2 * jax.local_device_count()
+    mocker.patch("os.curdir", tmp_path)
+    config = _get_config(vmc_nchains, eval_nchains, False)
+    config.dtype="float64"
+
+    _run_and_check_output_files(mocker, tmp_path, config)
+
 
 
 @pytest.mark.very_slow

--- a/tests/integrations/train/test_runners.py
+++ b/tests/integrations/train/test_runners.py
@@ -2,7 +2,6 @@
 import os
 
 import jax
-import jax.numpy as jnp
 import numpy as np
 import pytest
 
@@ -141,6 +140,7 @@ def test_run_molecule_jitted(mocker, tmp_path):
 
     _run_and_check_output_files(mocker, tmp_path, config)
 
+
 @pytest.mark.very_slow
 def test_run_molecule_double_precision(mocker, tmp_path):
     """End-to-end test of the molecular runner, in double precision."""
@@ -148,10 +148,9 @@ def test_run_molecule_double_precision(mocker, tmp_path):
     eval_nchains = 2 * jax.local_device_count()
     mocker.patch("os.curdir", tmp_path)
     config = _get_config(vmc_nchains, eval_nchains, False)
-    config.dtype="float64"
+    config.dtype = "float64"
 
     _run_and_check_output_files(mocker, tmp_path, config)
-
 
 
 @pytest.mark.very_slow

--- a/tests/integrations/train/test_runners.py
+++ b/tests/integrations/train/test_runners.py
@@ -142,6 +142,18 @@ def test_run_molecule_jitted(mocker, tmp_path):
 
 
 @pytest.mark.very_slow
+def test_run_molecule_double_precision(mocker, tmp_path):
+    """End-to-end test of the molecular runner, in double precision."""
+    vmc_nchains = 3 * jax.local_device_count()
+    eval_nchains = 2 * jax.local_device_count()
+    mocker.patch("os.curdir", tmp_path)
+    config = _get_config(vmc_nchains, eval_nchains, False)
+    config.dtype = "float64"
+
+    _run_and_check_output_files(mocker, tmp_path, config)
+
+
+@pytest.mark.very_slow
 def test_reload_append(mocker, tmp_path):
     """Reload and continue a run from a checkpoint.
 
@@ -218,17 +230,3 @@ def test_reload_append(mocker, tmp_path):
         print("test passed for", name)
 
     np.testing.assert_allclose(energies1, energies2, rtol=1e-6)
-
-
-# NOTE (ggoldsh): This test MUST be at the end of the file, otherwise it turns on
-# double precision for later tests and causes them to fail.
-@pytest.mark.very_slow
-def test_run_molecule_double_precision(mocker, tmp_path):
-    """End-to-end test of the molecular runner, in double precision."""
-    vmc_nchains = 3 * jax.local_device_count()
-    eval_nchains = 2 * jax.local_device_count()
-    mocker.patch("os.curdir", tmp_path)
-    config = _get_config(vmc_nchains, eval_nchains, False)
-    config.dtype = "float64"
-
-    _run_and_check_output_files(mocker, tmp_path, config)

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -510,7 +510,12 @@ def _make_new_data_for_eval(
     if config.distribute:
         key = utils.distribute.make_different_rng_key_on_all_devices(key)
     data = _make_initial_data(
-        log_psi_apply, config.eval, init_pos, params, apply_pmap=config.distribute
+        log_psi_apply,
+        config.eval,
+        init_pos,
+        params,
+        dtype=dtype,
+        apply_pmap=config.distribute,
     )
 
     return key, data

--- a/vmcnet/train/runners.py
+++ b/vmcnet/train/runners.py
@@ -74,6 +74,7 @@ def _save_git_hash(logdir):
 
 def _get_dtype(config: ConfigDict):
     if config.dtype == "float32":
+        jax.config.update("jax_enable_x64", False)
         return jnp.float32
     elif config.dtype == "float64":
         jax.config.update("jax_enable_x64", True)


### PR DESCRIPTION
I was testing double precision on NERSC to see if it fixed our numerical issues and I realized there was a bug in the MCMC logic where the move_acceptance_sum was always being initialized in float32 and then vmc-molecule would crash when it was updated.

This PR fixes it so both vmc and eval loops run properly in float32 and float64. Also adds a regression test.

