### PR TITLE
Add momentum option for ProxSR

### DIFF
--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -357,6 +357,7 @@ def get_default_vmc_config() -> Dict:
                 "learning_rate": 5e-2,  # needs to be tuned with everything else
                 "learning_decay_rate": 1e-4,
                 "mu": 0.99,
+                "momentum": 0.0,  # not recommended!
                 "damping": 0.001,
                 "constrain_norm": True,
                 "norm_constraint": 0.001,

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -357,7 +357,7 @@ def get_default_vmc_config() -> Dict:
                 "learning_rate": 5e-2,  # needs to be tuned with everything else
                 "learning_decay_rate": 1e-4,
                 "mu": 0.99,
-                "momentum": 0.0,  # not recommended!
+                "momentum": 0.0,  # non-zero value not recommended
                 "damping": 0.001,
                 "constrain_norm": True,
                 "norm_constraint": 0.001,

--- a/vmcnet/updates/parse_config.py
+++ b/vmcnet/updates/parse_config.py
@@ -586,6 +586,7 @@ def get_proxsr_update_fn_and_state(
         log_psi_apply,
         optimizer_config.damping,
         optimizer_config.mu,
+        optimizer_config.momentum,
     )
 
     descent_optimizer = optax.sgd(

--- a/vmcnet/updates/proxsr.py
+++ b/vmcnet/updates/proxsr.py
@@ -17,7 +17,7 @@ def get_proxsr_update_fn(
     log_psi_apply: ModelApply[P],
     damping: chex.Scalar = 0.001,
     mu: chex.Scalar = 0.99,
-    momentum: chex.Scalar = 0.99,
+    momentum: chex.Scalar = 0.0,
 ):
     """
     Get the ProxSR update function.

--- a/vmcnet/updates/proxsr.py
+++ b/vmcnet/updates/proxsr.py
@@ -17,6 +17,7 @@ def get_proxsr_update_fn(
     log_psi_apply: ModelApply[P],
     damping: chex.Scalar = 0.001,
     mu: chex.Scalar = 0.99,
+    momentum: chex.Scalar = 0.99,
 ):
     """
     Get the ProxSR update function.
@@ -66,6 +67,8 @@ def get_proxsr_update_fn(
         )
 
         SR_G = dtheta_residual + prev_grad_decayed
+        SR_G = (1 - momentum) * SR_G + momentum * prev_grad
+
         return unravel_fn(SR_G)
 
     return proxsr_update_fn


### PR DESCRIPTION
So that the new code can reproduce the old results of showing that Momentum does not improve MinSR.

MinSR + Momentum can be run by setting mu=0.0, momentum > 0.0.

PTAL @nilin 