### PR TITLE
Modify SPRING to use neural-tangents

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
         python-version: ['3.12']
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,11 +18,11 @@ install_requires =
     jax>=0.4.38
     jaxlib>=0.4.38
     kfac_jax==0.0.6
-    neural-tangents>=0.6.0
     dm-tree==0.1.8
     ml-collections==1.0.0
-    numpy==2.2.2
+    numpy>=2.0.2
     optax==0.2.4
+    neural-tangents>=0.6.5
 python_requires = >=3.9
 zip_safe = no
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ install_requires =
     jax>=0.4.38
     jaxlib>=0.4.38
     kfac_jax==0.0.6
-    neural-tangents>=0.5.0
+    neural-tangents>=0.6.0
     dm-tree==0.1.8
     ml-collections==1.0.0
     numpy==2.2.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ install_requires =
     jax>=0.4.38
     jaxlib>=0.4.38
     kfac_jax==0.0.6
+    neural-tangents>=0.5.0
     dm-tree==0.1.8
     ml-collections==1.0.0
     numpy==2.2.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,15 +13,15 @@ classifiers =
 packages =
     vmcnet
 install_requires =
-    absl-py>=0.12.0
+    jax>=0.4.34
+    jaxlib>=0.4.34
     flax==0.10.2
-    jax>=0.4.38
-    jaxlib>=0.4.38
-    kfac_jax==0.0.6
-    dm-tree==0.1.8
-    ml-collections==1.0.0
-    numpy>=2.0.2
     optax==0.2.4
+    dm-tree==0.1.8
+    kfac_jax==0.0.6
+    numpy>=1.26.4
+    ml-collections==1.0.0
+    absl-py>=0.12.0
     neural-tangents>=0.6.5
 python_requires = >=3.9
 zip_safe = no

--- a/vmcnet/train/default_config.py
+++ b/vmcnet/train/default_config.py
@@ -165,7 +165,7 @@ def get_default_model_config() -> Dict:
     base_ferminet_config = {
         "input_streams": input_streams,
         "backflow": ferminet_backflow,
-        "ndeterminants": 1,
+        "ndeterminants": 16,
         "kernel_init_orbital_linear": {"type": "orthogonal", "scale": 2.0},
         "kernel_init_envelope_dim": {"type": "ones"},
         "kernel_init_envelope_ion": {"type": "ones"},
@@ -176,7 +176,7 @@ def get_default_model_config() -> Dict:
         "use_det_resnet": False,
         "det_resnet": determinant_resnet,
         "determinant_fn_mode": "parallel_even",
-        "full_det": False,
+        "full_det": True,
     }
 
     invariance_for_antieq = {
@@ -292,7 +292,7 @@ def get_default_molecular_config() -> Dict:
 def get_default_vmc_config() -> Dict:
     """Get a default VMC training configuration."""
     vmc_config = {
-        "nchains": 2000,
+        "nchains": 1000,
         "nepochs": 200000,
         "nburn": 5000,
         "nsteps_per_param_update": 10,
@@ -372,7 +372,7 @@ def get_default_vmc_config() -> Dict:
 def get_default_eval_config() -> Dict:
     """Get a default evaluation configuration."""
     eval_config = {
-        "nchains": 2000,
+        "nchains": 1000,
         "nburn": 5000,
         "nepochs": 20000,
         "nsteps_per_param_update": 10,

--- a/vmcnet/updates/spring.py
+++ b/vmcnet/updates/spring.py
@@ -3,7 +3,7 @@
 import jax
 import jax.flatten_util
 import jax.numpy as jnp
-import neural_tangents as nt
+import neural_tangents as nt  # type: ignore
 
 from vmcnet.utils.typing import Array, ModelApply, P, Tuple
 
@@ -34,7 +34,6 @@ def get_spring_update_fn(
         Callable: SPRING update function. Has the signature
         (centered_energies, params, prev_grad, positions) -> new_grad
     """
-
     kernel_fn = nt.empirical_kernel_fn(log_psi_apply, vmap_axes=0, trace_axes=())
 
     def spring_update_fn(
@@ -48,11 +47,13 @@ def get_spring_update_fn(
         ones = jnp.ones((nchains, 1))
 
         # Calculate T = Ohat @ Ohat^T using neural-tangents
-        # Some GPUs, particularly A100s and A5000s, can exhibit large numerical errors in these
-        # calculations. As a result, we explicitly symmetrize T and, rather than using a Cholesky
-        # solver to solve against T, we calculate its eigendecomposition and explicitly fix any negative
-        # eigenvalues. We then use the fixed and regularized igendecomposition to solve against T.
-        # This appears to be more stable than Cholesky in practice.
+        # Some GPUs, particularly A100s and A5000s, can exhibit large numerical
+        # errors in these calculations. As a result, we explicitly symmetrize T
+        # and, rather than using a Cholesky solver to solve against T, we
+        # calculate its eigendecomposition and explicitly fix any negative
+        # eigenvalues. We then use the fixed and regularized igendecomposition
+        # to solve against T. This appears to be more stable than Cholesky
+        # in practice.
         T = kernel_fn(positions, positions, "ntk", params) / nchains
         T = T - jnp.mean(T, axis=0, keepdims=True)
         T = T - jnp.mean(T, axis=1, keepdims=True)

--- a/vmcnet/updates/spring.py
+++ b/vmcnet/updates/spring.py
@@ -39,7 +39,7 @@ def get_spring_update_fn(
         log_grads = jax.grad(log_psi_apply)(params, positions)
         return jax.flatten_util.ravel_pytree(log_grads)[0]
 
-    batch_raveled_log_psi_grad = jax.vmap(raveled_log_psi_grad, trace_axes=(), in_axes=(None, 0))
+    batch_raveled_log_psi_grad = jax.vmap(raveled_log_psi_grad, in_axes=(None, 0))
 
     kernel_fn = nt.empirical_kernel_fn(log_psi_apply, vmap_axes=0)
 


### PR DESCRIPTION
- Use neural-tangents library to reduce memory usage
- Modify SPRING implementation to be more stable on A5000, by using eigh instead of cholesky
